### PR TITLE
MILAB-3331 Review usage of trace annotation

### DIFF
--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -60,6 +60,9 @@ wf.prepare(func(args) {
 )
 
 wf.body(func(args) {
+
+	blockId := wf.blockId().getDataAsJson()
+
 	columnsWithSequences := args.columns
 	sequences := columnsWithSequences.getColumns("sequences")
 	annotations := columnsWithSequences.getColumns("annotations")
@@ -168,6 +171,7 @@ wf.body(func(args) {
 		liabilitiesTable: liabilitiesResult,
 		newMapping: newMapping,
 		regionsFound: regionsFound,
+		blockId: blockId,
 		params: smart.createJsonResource({
 			datasetSpec: datasetSpec,
 			isSingleCell: isSingleCell,

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -14,6 +14,8 @@ self.defineOutputs("outputLiabilities", "exportPframe")
 
 self.body(func(args) {
 
+    blockId := args.blockId
+	
     params := args.params
     liabilitiesTable := args.liabilitiesTable
     datasetSpec := params.datasetSpec
@@ -240,14 +242,18 @@ self.body(func(args) {
 
 
 
-
+	// Pick export columns and add blockId to the domain
 	exportColumns := []
 	for col in columns {
-		if col.spec.name == "pl7.app/vdj/sequence/annotation" {
-			exportColumns += [col]
-		} else if col.spec.annotations["pl7.app/isScore"] == "true" {
-			exportColumns += [col]
-		} else if col.spec.annotations["pl7.app/isSummary"] == "true" {
+		if col.spec.name == "pl7.app/vdj/sequence/annotation" ||
+			(col.spec.annotations && col.spec.annotations["pl7.app/isScore"] == "true") ||
+			(col.spec.annotations && col.spec.annotations["pl7.app/isSummary"] == "true") {
+
+			if !col.spec.domain {
+				col.spec.domain = {}
+			}
+			col.spec.domain["pl7.app/blockId"] = blockId
+			
 			exportColumns += [col]
 		}
 	}

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -28,10 +28,6 @@ self.body(func(args) {
 
     clonotypeKeySpec := datasetSpec.axesSpec[1]
 
-    // Create a trace for tracking the liabilities calculation
-	trace := pSpec.makeTrace(datasetSpec,
-		{type: "milaboratories.antibody-sequence-liabilities", importance: 30, label: "Liabilities risk"})
-
     // Set up the axes for the output data - using clonotype key
 	axes := [
 		{
@@ -289,10 +285,33 @@ self.body(func(args) {
         {splitDataAndSpec: true, cpu: 1, mem: "16GiB"}
 	)
 
+	// Create the base block-level trace
+	traceSteps := [{
+		type: "milaboratories.antibody-sequence-liabilities",
+		importance: 30,
+		label: "Liabilities risk",
+		id: blockId
+	}]
+
+	// Add individual trace steps for each liability type with decreasing importance
+	importance := 29
+	for liabilityType in liabilityTypes {
+		traceSteps += [{
+			type: "milaboratories.antibody-sequence-liabilities/" + text.to_lower(text.re_replace(" ", liabilityType , "-")),
+			importance: importance,
+			label: liabilityType,
+			id: blockId
+		}]
+		importance -= 1
+	}
+
+	// Create the trace with all steps. Spread operator is used to pass the trace steps as individual arguments.
+	liabilityTrace := pSpec.makeTrace(datasetSpec, traceSteps...)
+
 	exportPframe := pframes.pFrameBuilder()
 
 	for k, v in exportOutput {
-		exportPframe.add(k, trace.inject(v.spec), v.data)
+		exportPframe.add(k, liabilityTrace.inject(v.spec), v.data)
 	}
 
 	exportPframe = exportPframe.build()

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -99,7 +99,6 @@ self.body(func(args) {
 					valueType: "String",
 					domain: { "pl7.app/vdj/feature": f_name },
 					annotations: {
-						"pl7.app/trace": trace.valueStr,
 						"pl7.app/label": f_name + " Liabilities",
 						"pl7.app/table/visibility": "default",
 						"pl7.app/table/orderPriority": string(orderPriorityBase)
@@ -116,7 +115,6 @@ self.body(func(args) {
 					valueType: "String",
 					domain: { "pl7.app/vdj/feature": f_name },
 					annotations: {
-						"pl7.app/trace": trace.valueStr,
 						"pl7.app/label": f_name + " Risk",
 						"pl7.app/table/visibility": "default",
 						"pl7.app/isDiscreteFilter": "true",
@@ -152,7 +150,6 @@ self.body(func(args) {
 						"pl7.app/vdj/scClonotypeChain/index": "primary"
 					},
 					annotations: {
-						"pl7.app/trace": trace.valueStr,
 						"pl7.app/label": chainLabel + " " + "CDR3 aa",
 						"pl7.app/table/visibility": "default",
 						"pl7.app/table/orderPriority": "101"
@@ -176,7 +173,6 @@ self.body(func(args) {
                             "pl7.app/sequence/annotation/type": "CDRs" // Type of annotation
                         },
                         annotations: {
-                            "pl7.app/trace": trace.valueStr,
                             "pl7.app/label": chainLabel + " CDRs Annotations",
                             "pl7.app/table/visibility": "hidden",
                             "pl7.app/table/orderPriority": "102",
@@ -201,7 +197,6 @@ self.body(func(args) {
 					"pl7.app/vdj/feature": "CDR3"
 				},
 				annotations: {
-					"pl7.app/trace": trace.valueStr,
 					"pl7.app/label": "CDR3 aa",
 					"pl7.app/table/visibility": "default",
 					"pl7.app/table/orderPriority": "101"
@@ -223,7 +218,6 @@ self.body(func(args) {
 					"pl7.app/sequence/annotation/type": "CDRs"
 				},
 				annotations: {
-					"pl7.app/trace": trace.valueStr,
 					"pl7.app/label": "annotations",
 					"pl7.app/table/visibility": "hidden",
 					"pl7.app/table/orderPriority": "102",


### PR DESCRIPTION
**Objective:** Improve trace annotation to be able distinguish between exports of different liabilities blocks.  

**Changes:**

*   Removed manual traces: `"pl7.app/trace": trace.valueStr`

*   Added `blockId` to `main.tpl.tengo` and passed to `processTpl` template (needed to avoid errors with multiple cols in `antibody-tcr-leads`). For columns that are exported (`annotation`, `isScore`, or `isSummary`), the `blockId` is now added to their `spec.domain` too.

*   **Trace Steps**: Besides the previous block-level trace, now there are trace steps for each liability. This allows deduplication of exported columns according to the liability types that were selected in each block.


For example when there are 2 `Liabilities risk` columns available, they will show as: Liabilities Risk + one of the types is present in only one of the two (selected by higher importance).

This is what shows for the output of 2 blocks with:
- Deamidation (N[GS]), Fragmentation (DP), Isomerization (D[DGHST])
- Deamidation (N[GS]), Fragmentation (DP), Isomerization (D(DGHST]), Missing Cysteines, Methionine Oxidation (M)

In `antibody-tcr-leads`:

<img width="898" height="261" alt="image" src="https://github.com/user-attachments/assets/794aefb1-0e93-4766-aaea-e8bdc0946486" />




