### PR TITLE
fix: per-region risk reflects all liability fixabilities

### DIFF
--- a/.changeset/fix-per-region-risk-aggregation.md
+++ b/.changeset/fix-per-region-risk-aggregation.md
@@ -6,6 +6,6 @@ Fix: per-region "{region} Risk" columns now reflect any matching liability, not 
 
 Previously, when a region matched a `hard_to_fix` or `structural` liability (e.g. `Extra Cysteines`, or a custom liability with fixability `Hard to fix`), the corresponding `{region} Risk` column reported `None`, even though `{region} Liabilities` listed the liability. The two columns now agree: `{region} Risk` is the worst `riskLevel` of any non-disqualifying liability detected in that region.
 
-The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` listed both behaviors as defensible and deferred the call to the implementor. The original v4.0.0 implementation picked Option A (engineering-only); this release switches to Option B (all non-disqualifying), which the spec named as the alternative.
+The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` listed both behaviors as defensible and deferred the call to the implementor. The original v4.0.0 implementation picked Option A (engineering-only); this release switches to Option B (all non-disqualifying).
 
 Global behavior is unchanged: `Developability risk` still aggregates only `fixable` + `easily_fixable` liabilities, and `Structural liabilities` still flags `Present` for `hard_to_fix` / `structural` matches.

--- a/.changeset/fix-per-region-risk-aggregation.md
+++ b/.changeset/fix-per-region-risk-aggregation.md
@@ -16,4 +16,4 @@ The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/READM
 
 The discrete scale becomes `[None, Low, Medium, High, Very High, Non-Developable]`. Default cutoff stays `[None, Low, Medium]`, so High, Very High, and Non-Developable are all filtered out by default — readers no longer need to cross-reference `Structural liabilities` to spot disqualified candidates.
 
-`Structural liabilities` itself is unchanged.
+`Structural liabilities` is hidden by default — Developability risk's `Very High` and `Non-Developable` values now carry its signal at higher resolution. The column stays available via the column picker for users who want the raw boolean.

--- a/.changeset/fix-per-region-risk-aggregation.md
+++ b/.changeset/fix-per-region-risk-aggregation.md
@@ -1,0 +1,11 @@
+---
+"@platforma-open/milaboratories.antibody-sequence-liabilities": patch
+---
+
+Fix: per-region "{region} Risk" columns now reflect any matching liability, not just engineering-fixable ones.
+
+Previously, when a region matched a `hard_to_fix` or `structural` liability (e.g. `Extra Cysteines`, or a custom liability with fixability `Hard to fix`), the corresponding `{region} Risk` column reported `None`, even though `{region} Liabilities` listed the liability. The two columns now agree: `{region} Risk` is the worst `riskLevel` of any non-disqualifying liability detected in that region.
+
+The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` listed both behaviors as defensible and deferred the call to the implementor. The original v4.0.0 implementation picked Option A (engineering-only); this release switches to Option B (all non-disqualifying), which the spec named as the alternative.
+
+Global behavior is unchanged: `Developability risk` still aggregates only `fixable` + `easily_fixable` liabilities, and `Structural liabilities` still flags `Present` for `hard_to_fix` / `structural` matches.

--- a/.changeset/fix-per-region-risk-aggregation.md
+++ b/.changeset/fix-per-region-risk-aggregation.md
@@ -8,4 +8,6 @@ Previously, when a region matched a `hard_to_fix` or `structural` liability (e.g
 
 The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` listed both behaviors as defensible and deferred the call to the implementor. The original v4.0.0 implementation picked Option A (engineering-only); this release switches to Option B (all non-disqualifying).
 
-Global behavior is unchanged: `Developability risk` still aggregates only `fixable` + `easily_fixable` liabilities, and `Structural liabilities` still flags `Present` for `hard_to_fix` / `structural` matches.
+`Developability risk` gains a new top-level value `Non-Developable`, returned whenever any `structural` or `hard_to_fix` liability is present (mirrors `Structural liabilities = Present`). The discrete scale becomes `[None, Low, Medium, High, Non-Developable]`. Lead Selection's default cutoff stays `[None, Low, Medium]`, so structurally compromised candidates are filtered out by this column too — readers no longer need to cross-reference `Structural liabilities` to spot them.
+
+`Structural liabilities` is unchanged.

--- a/.changeset/fix-per-region-risk-aggregation.md
+++ b/.changeset/fix-per-region-risk-aggregation.md
@@ -8,6 +8,12 @@ Previously, when a region matched a `hard_to_fix` or `structural` liability (e.g
 
 The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` listed both behaviors as defensible and deferred the call to the implementor. The original v4.0.0 implementation picked Option A (engineering-only); this release switches to Option B (all non-disqualifying).
 
-`Developability risk` gains a new top-level value `Non-Developable`, returned whenever any `structural` or `hard_to_fix` liability is present (mirrors `Structural liabilities = Present`). The discrete scale becomes `[None, Low, Medium, High, Non-Developable]`. Lead Selection's default cutoff stays `[None, Low, Medium]`, so structurally compromised candidates are filtered out by this column too — readers no longer need to cross-reference `Structural liabilities` to spot them.
+`Developability risk` gains two new top-level values that fold the structural-liability signal into this column:
 
-`Structural liabilities` is unchanged.
+- `hard_to_fix` liabilities (e.g. `Extra Cysteines`, custom liabilities marked "Hard to fix") → `Very High`
+- `structural` liabilities (e.g. `Missing Cysteines`) → `Non-Developable`
+- Both present in the same row → `Non-Developable` wins
+
+The discrete scale becomes `[None, Low, Medium, High, Very High, Non-Developable]`. Default cutoff stays `[None, Low, Medium]`, so High, Very High, and Non-Developable are all filtered out by default — readers no longer need to cross-reference `Structural liabilities` to spot disqualified candidates.
+
+`Structural liabilities` itself is unchanged.

--- a/docs/description.md
+++ b/docs/description.md
@@ -6,11 +6,10 @@ The block evaluates sequences for deamidation (`N[GS]`, `N[AHNT]`, `[STK]N`), fr
 
 Two output columns are emitted for both modalities:
 
-- **Developability risk** — `None`/`Low`/`Medium`/`High`: severity of fixable liabilities (PTM motifs, fragmentation sites)
+- **Developability risk** — `None` / `Low` / `Medium` / `High` / `Very High` / `Non-Developable`: engineering severity for fixable liabilities at the lower end of the scale; `Very High` when a Hard to fix liability is present (e.g. Extra Cysteines); `Non-Developable` when a Structural liability is present (e.g. Missing Cysteines)
 - **Developability cost** — continuous score: sum of engineering effort weighted by fixability class (antibody mode also weights by region importance); lower = easier to engineer
 
 Antibody/TCR inputs additionally produce:
 - **Is Productive** — `Pass`/`Fail`: fails on stop codons or out-of-frame sequences
-- **Structural liabilities** — `None`/`Present`: flags missing or extra cysteines
 
 You can extend the predefined liability set with custom motifs defined in the block settings or imported from a JSON file.

--- a/liabilities-calc-script/src/definitions.py
+++ b/liabilities-calc-script/src/definitions.py
@@ -1,3 +1,14 @@
+from typing import Literal, TypeAlias
+
+# Type aliases for the bounded enum strings used across detection / scoring / Tengo.
+# Centralising these catches typos and serves as the source of truth that the
+# Tengo PColumn discreteValues annotations must match.
+Fixability: TypeAlias = Literal["disqualifying", "structural", "hard_to_fix", "fixable", "easily_fixable"]
+RiskLevel: TypeAlias = Literal["Low", "Medium", "High"]
+PerRegionRisk: TypeAlias = Literal["None", "Low", "Medium", "High"]
+DevelopabilityRisk: TypeAlias = Literal["None", "Low", "Medium", "High", "Very High", "Non-Developable"]
+
+
 # Liability Definitions
 # Format: name → (pattern, risk_level, fixability)
 ORIG_REGEX_LIABILITIES = {
@@ -15,17 +26,19 @@ ORIG_REGEX_LIABILITIES = {
 }
 
 # Phase 1 enabled set for peptide modality.
-PEPTIDE_LIABILITY_NAMES = frozenset({
-    "Deamidation (N[GS])",
-    "Fragmentation (DP)",
-    "Isomerization (D[DGHST])",
-    "Deamidation (N[AHNT])",
-    "Hydrolysis (NP)",
-    "Tryptophan Oxidation (W)",
-    "Methionine Oxidation (M)",
-    "Deamidation ([STK]N)",
-    "Integrin binding",
-})
+PEPTIDE_LIABILITY_NAMES = frozenset(
+    {
+        "Deamidation (N[GS])",
+        "Fragmentation (DP)",
+        "Isomerization (D[DGHST])",
+        "Deamidation (N[AHNT])",
+        "Hydrolysis (NP)",
+        "Tryptophan Oxidation (W)",
+        "Methionine Oxidation (M)",
+        "Deamidation ([STK]N)",
+        "Integrin binding",
+    }
+)
 # Format: name → pattern  (fixability is always "disqualifying")
 ORIG_EXTRA_PATTERNS = {
     "Contains stop codon": r"\*",
@@ -38,7 +51,9 @@ ORIG_CYS_LIABILITIES = {
 }
 
 # Unified fixability lookup for all predefined liabilities
-FIXABILITY_MAP: dict[str, str] = {name: fixability for name, (_pat, _risk, fixability) in ORIG_REGEX_LIABILITIES.items()}
+FIXABILITY_MAP: dict[str, Fixability] = {
+    name: fixability for name, (_pat, _risk, fixability) in ORIG_REGEX_LIABILITIES.items()
+}
 FIXABILITY_MAP.update({name: "disqualifying" for name in ORIG_EXTRA_PATTERNS})
 FIXABILITY_MAP.update({name: fixability for name, (_risk, fixability) in ORIG_CYS_LIABILITIES.items()})
 

--- a/liabilities-calc-script/src/detection.py
+++ b/liabilities-calc-script/src/detection.py
@@ -1,7 +1,5 @@
 import re
 
-from definitions import ORIG_REGEX_LIABILITIES, ORIG_CYS_LIABILITIES
-
 
 # Cysteine position helpers
 def _get_expected_cys_positions(region: str, expected_cys_map: dict):

--- a/liabilities-calc-script/src/detection.py
+++ b/liabilities-calc-script/src/detection.py
@@ -1,6 +1,6 @@
 import re
 
-from definitions import ORIG_REGEX_LIABILITIES, ORIG_CYS_LIABILITIES, _ENGINEERING_FIXABILITIES
+from definitions import ORIG_REGEX_LIABILITIES, ORIG_CYS_LIABILITIES
 
 
 # Cysteine position helpers
@@ -108,7 +108,23 @@ def classify_risk(
     fixability_map: dict[str, str],
     risk_level_map: dict[str, str] | None = None,
 ) -> str:
-    """Per-region engineering risk — counts fixable and easily_fixable liabilities only."""
+    """Per-region risk: worst riskLevel across all non-disqualifying liabilities
+    detected in the region's liabilities column.
+
+    The spec (docs/text/work/projects/sequence-liability-fixability-scoring/README.md)
+    flagged this at line :126 (Open Questions) as a coin-flip with two defensible
+    options: (A) per-region risk reflects fixable + easily_fixable only, or (B)
+    per-region risk reflects all liabilities except disqualifying. The implementor
+    picked A; R8 (:71), Step 2 (:252-253), Defaults (:304), M1 (:346), and Risks
+    (:395) then encoded that choice as binding. User feedback (Slack 2026-05-24)
+    showed A's predicted counter-argument materialized — per-region Liabilities
+    and Risk columns visibly disagree when a region's only liabilities are
+    hard_to_fix / structural. This function now implements Option B.
+
+    Engineering-only severity is still available in the global "Developability
+    risk" column (see scoring.classify_developability_risk), which keeps
+    Option-A semantics per R6 (:66).
+    """
     if not liabilities_str or liabilities_str == "None" or not isinstance(liabilities_str, str):
         return "None"
     items = [item.strip() for item in liabilities_str.split(",")]
@@ -116,16 +132,20 @@ def classify_risk(
     level_to_risk = {v: k for k, v in risk_num.items()}
     current_max = 0
     for item in items:
-        if fixability_map.get(item) not in _ENGINEERING_FIXABILITIES:
-            continue  # Disqualifying, structural, and hard_to_fix excluded from per-region risk
+        if fixability_map.get(item) == "disqualifying":
+            continue
         if item in active_cys_defs:
             item_risk = active_cys_defs[item][0]  # (risk_level, fixability)
         elif item in active_cdr_defs:
             item_risk = active_cdr_defs[item][1]  # (pattern, risk_level, fixability)
         elif item in active_extra_pattern_names:
+            # All current active_extra_pattern_names entries are disqualifying
+            # (stop codon, OOF) so the disqualifying skip above filters them out.
+            # Branch retained so the function stays correct if a future
+            # non-disqualifying "extra" liability is added.
             item_risk = "High"
         elif risk_level_map and item in risk_level_map:
-            item_risk = risk_level_map[item]  # custom liability
+            item_risk = risk_level_map[item]  # custom liability or predefined cys/cdr fallback
         else:
             continue
         level = risk_num.get(item_risk, 0)

--- a/liabilities-calc-script/src/detection.py
+++ b/liabilities-calc-script/src/detection.py
@@ -100,14 +100,18 @@ def identify_liabilities(
 
 def classify_risk(
     liabilities_str: str,
-    active_cdr_defs: dict,
-    active_cys_defs: dict,
-    active_extra_pattern_names: set,
     fixability_map: dict[str, str],
-    risk_level_map: dict[str, str] | None = None,
+    risk_level_map: dict[str, str],
 ) -> str:
     """Per-region risk: worst riskLevel across all non-disqualifying liabilities
     detected in the region's liabilities column.
+
+    Looks up each liability's risk level in `risk_level_map`, which the caller
+    (main.py) builds by merging predefined CDR / Cys liability definitions
+    (via _build_risk_level_map) with any custom liabilities. Skips items whose
+    fixability is `disqualifying` — those are surfaced via Is Productive = Fail
+    and would otherwise force every region to High because identify_liabilities
+    appends them to every region's liabilities string.
 
     The spec (docs/text/work/projects/sequence-liability-fixability-scoring/README.md)
     flagged this at line :126 (Open Questions) as a coin-flip with two defensible
@@ -121,30 +125,19 @@ def classify_risk(
 
     Engineering-only severity is still available in the global "Developability
     risk" column (see scoring.classify_developability_risk), which keeps
-    Option-A semantics per R6 (:66).
+    Option-A semantics per R6 (:66) plus a Non-Developable override when
+    structural / hard_to_fix matches are present.
     """
     if not liabilities_str or liabilities_str == "None" or not isinstance(liabilities_str, str):
         return "None"
-    items = [item.strip() for item in liabilities_str.split(",")]
     risk_num = {"None": 0, "Low": 1, "Medium": 2, "High": 3}
     level_to_risk = {v: k for k, v in risk_num.items()}
     current_max = 0
-    for item in items:
+    for item in (n.strip() for n in liabilities_str.split(",")):
         if fixability_map.get(item) == "disqualifying":
             continue
-        if item in active_cys_defs:
-            item_risk = active_cys_defs[item][0]  # (risk_level, fixability)
-        elif item in active_cdr_defs:
-            item_risk = active_cdr_defs[item][1]  # (pattern, risk_level, fixability)
-        elif item in active_extra_pattern_names:
-            # All current active_extra_pattern_names entries are disqualifying
-            # (stop codon, OOF) so the disqualifying skip above filters them out.
-            # Branch retained so the function stays correct if a future
-            # non-disqualifying "extra" liability is added.
-            item_risk = "High"
-        elif risk_level_map and item in risk_level_map:
-            item_risk = risk_level_map[item]  # custom liability or predefined cys/cdr fallback
-        else:
+        item_risk = risk_level_map.get(item)
+        if not item_risk:
             continue
         level = risk_num.get(item_risk, 0)
         if level > current_max:

--- a/liabilities-calc-script/src/detection.py
+++ b/liabilities-calc-script/src/detection.py
@@ -115,9 +115,9 @@ def classify_risk(
     per-region risk reflects all liabilities except disqualifying. The implementor
     picked A; R8 (:71), Step 2 (:252-253), Defaults (:304), M1 (:346), and Risks
     (:395) then encoded that choice as binding. User feedback (Slack 2026-05-24)
-    showed A's predicted counter-argument materialized — per-region Liabilities
-    and Risk columns visibly disagree when a region's only liabilities are
-    hard_to_fix / structural. This function now implements Option B.
+    confirmed A's counter-argument: per-region Liabilities and Risk visibly
+    disagree when a region carries only hard_to_fix / structural matches. This
+    function now implements Option B.
 
     Engineering-only severity is still available in the global "Developability
     risk" column (see scoring.classify_developability_risk), which keeps

--- a/liabilities-calc-script/src/detection.py
+++ b/liabilities-calc-script/src/detection.py
@@ -1,5 +1,7 @@
 import re
 
+from definitions import Fixability, PerRegionRisk, RiskLevel
+
 
 # Cysteine position helpers
 def _get_expected_cys_positions(region: str, expected_cys_map: dict):
@@ -26,7 +28,7 @@ def _evaluate_cys_liabilities(seq: str, expected_positions: list, expected_count
 
 # Liability & Risk Functions
 def identify_liabilities(
-    seq: str,
+    seq: str | None,
     region: str,
     active_cdr_defs: dict,
     active_extra_defs: dict,
@@ -99,10 +101,10 @@ def identify_liabilities(
 
 
 def classify_risk(
-    liabilities_str: str,
-    fixability_map: dict[str, str],
-    risk_level_map: dict[str, str],
-) -> str:
+    liabilities_str: str | None,
+    fixability_map: dict[str, Fixability],
+    risk_level_map: dict[str, RiskLevel],
+) -> PerRegionRisk:
     """Per-region risk: worst riskLevel across all non-disqualifying liabilities
     detected in the region's liabilities column.
 
@@ -147,9 +149,9 @@ def classify_risk(
     return level_to_risk[current_max]
 
 
-def _build_risk_level_map(active_cdr_defs: dict, active_cys_defs: dict) -> dict[str, str]:
+def _build_risk_level_map(active_cdr_defs: dict, active_cys_defs: dict) -> dict[str, RiskLevel]:
     """Build a liability_name → risk_level lookup from active predefined definitions."""
-    risk_map = {}
+    risk_map: dict[str, RiskLevel] = {}
     for name, (_pat, risk, *_rest) in active_cdr_defs.items():
         risk_map[name] = risk
     for name, (risk, _fix) in active_cys_defs.items():

--- a/liabilities-calc-script/src/main.py
+++ b/liabilities-calc-script/src/main.py
@@ -11,9 +11,9 @@ from polars.exceptions import ShapeError
 from annotations import base36_encode, extract_cdrs_fr1, parse_annotations
 from definitions import (
     FIXABILITY_MAP,
-    ORIG_REGEX_LIABILITIES,
     ORIG_CYS_LIABILITIES,
     ORIG_EXTRA_PATTERNS,
+    ORIG_REGEX_LIABILITIES,
     REGION_ORDER_MAP,
     build_expected_cys_map,
     get_active_liability_definitions,
@@ -27,8 +27,6 @@ from detection import (
 )
 from scoring import (
     classify_developability_risk,
-    classify_is_productive,
-    classify_structural_risk,
     compute_developability_score,
 )
 
@@ -40,11 +38,7 @@ def _is_productive_expr(liab_cols: list[str], fixability_map: dict[str, str]) ->
     Uses vectorised str.contains + any_horizontal instead of per-row map_elements.
     """
     disqualifying = {name for name, fix in fixability_map.items() if fix == "disqualifying"}
-    conditions = [
-        pl.col(c).str.contains(name, literal=True)
-        for c in liab_cols
-        for name in disqualifying
-    ]
+    conditions = [pl.col(c).str.contains(name, literal=True) for c in liab_cols for name in disqualifying]
     if not conditions:
         return pl.lit("Pass")
     return pl.when(pl.any_horizontal(conditions)).then(pl.lit("Fail")).otherwise(pl.lit("Pass"))
@@ -57,11 +51,7 @@ def _structural_risk_expr(liab_cols: list[str], fixability_map: dict[str, str]) 
     Uses vectorised str.contains + any_horizontal instead of per-row map_elements.
     """
     structural = {name for name, fix in fixability_map.items() if fix in {"structural", "hard_to_fix"}}
-    conditions = [
-        pl.col(c).str.contains(name, literal=True)
-        for c in liab_cols
-        for name in structural
-    ]
+    conditions = [pl.col(c).str.contains(name, literal=True) for c in liab_cols for name in structural]
     if not conditions:
         return pl.lit("None")
     return pl.when(pl.any_horizontal(conditions)).then(pl.lit("Present")).otherwise(pl.lit("None"))
@@ -291,9 +281,7 @@ def main():
         raw_names = args.include_liabilities.split(",")
         USER_REQUESTED_LIABILITIES = {name.strip() for name in raw_names if name.strip()}
     else:
-        USER_REQUESTED_LIABILITIES = (
-            set(ORIG_REGEX_LIABILITIES) | set(ORIG_EXTRA_PATTERNS) | set(ORIG_CYS_LIABILITIES)
-        )
+        USER_REQUESTED_LIABILITIES = set(ORIG_REGEX_LIABILITIES) | set(ORIG_EXTRA_PATTERNS) | set(ORIG_CYS_LIABILITIES)
 
     if use_predefined:
         active_cdr_defs, active_extra_defs, active_cys_defs, active_liability_regex = get_active_liability_definitions(
@@ -338,7 +326,9 @@ def main():
 
     expected_cys_map = build_expected_cys_map(args.numbering_schema)
 
-    if not (active_cdr_defs or active_extra_defs or active_cys_defs or active_custom_defs or active_extra_defs_full_seq):
+    if not (
+        active_cdr_defs or active_extra_defs or active_cys_defs or active_custom_defs or active_extra_defs_full_seq
+    ):
         print(
             "Warning: no active liability definitions after applying predefined/disabled/custom settings."
             " Liability calculations will be skipped."
@@ -393,9 +383,9 @@ def main():
     # the full chain avoids these false positives in per-region fragments.
     _fragment_keys_lower = {"cdr1", "cdr2", "cdr3", "fr1", "fr2", "fr3", "fr4"}
     full_input_sequence_cols = [
-        c for c in df_processed.columns
-        if c.lower().endswith(" aa")
-        and not any(k in c.lower() for k in _fragment_keys_lower)
+        c
+        for c in df_processed.columns
+        if c.lower().endswith(" aa") and not any(k in c.lower() for k in _fragment_keys_lower)
     ]
 
     if has_input_ann_cols:
@@ -693,8 +683,7 @@ def main():
                 .cast(pl.Utf8)
                 .map_elements(
                     lambda l_str, cfm=combined_fixability_map, rlm=combined_risk_level_map: classify_risk(
-                        l_str, active_cdr_defs, active_cys_defs,
-                        set(active_extra_defs_for_per_region.keys()) | set(active_extra_defs_full_seq.keys()), cfm, rlm
+                        l_str, cfm, rlm
                     ),
                     return_dtype=pl.Utf8,
                     skip_nulls=False,

--- a/liabilities-calc-script/src/scoring.py
+++ b/liabilities-calc-script/src/scoring.py
@@ -1,16 +1,26 @@
 import re
+from typing import Literal
 
-from definitions import _ENGINEERING_FIXABILITIES, FIXABILITY_WEIGHTS, REGION_WEIGHTS
+from definitions import (
+    _ENGINEERING_FIXABILITIES,
+    FIXABILITY_WEIGHTS,
+    REGION_WEIGHTS,
+    DevelopabilityRisk,
+    Fixability,
+    RiskLevel,
+)
 
 
-def _parse_liability_names(liabs_str: str) -> list[str]:
+def _parse_liability_names(liabs_str: str | None) -> list[str]:
     """Parse comma-separated liability string to a list of names, excluding None/Unknown."""
     if not liabs_str or liabs_str in ("None", "Unknown"):
         return []
     return [name.strip() for name in liabs_str.split(",") if name.strip() not in ("", "None", "Unknown")]
 
 
-def classify_is_productive(region_to_liabs: dict[str, str], fixability_map: dict[str, str]) -> str:
+def classify_is_productive(
+    region_to_liabs: dict[str, str | None], fixability_map: dict[str, Fixability]
+) -> Literal["Pass", "Fail"]:
     """Fail if any disqualifying liability is found in any region."""
     for liabs_str in region_to_liabs.values():
         for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
@@ -19,7 +29,9 @@ def classify_is_productive(region_to_liabs: dict[str, str], fixability_map: dict
     return "Pass"
 
 
-def classify_structural_risk(region_to_liabs: dict[str, str], fixability_map: dict[str, str]) -> str:
+def classify_structural_risk(
+    region_to_liabs: dict[str, str | None], fixability_map: dict[str, Fixability]
+) -> Literal["None", "Present"]:
     """Present if any structural or hard_to_fix liability is found in any region."""
     for liabs_str in region_to_liabs.values():
         for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
@@ -29,10 +41,10 @@ def classify_structural_risk(region_to_liabs: dict[str, str], fixability_map: di
 
 
 def classify_developability_risk(
-    region_to_liabs: dict[str, str],
-    fixability_map: dict[str, str],
-    risk_level_map: dict[str, str],
-) -> str:
+    region_to_liabs: dict[str, str | None],
+    fixability_map: dict[str, Fixability],
+    risk_level_map: dict[str, RiskLevel],
+) -> DevelopabilityRisk:
     """Developability risk with two structural overrides.
 
     Precedence (worst wins):
@@ -80,8 +92,8 @@ def classify_developability_risk(
 
 
 def compute_developability_score(
-    col_to_liabs: dict[str, str],
-    fixability_map: dict[str, str],
+    col_to_liabs: dict[str, str | None],
+    fixability_map: dict[str, Fixability],
 ) -> float:
     """Engineering burden: sum of fixability_weight × region_weight for all non-disqualifying liabilities.
 

--- a/liabilities-calc-script/src/scoring.py
+++ b/liabilities-calc-script/src/scoring.py
@@ -33,33 +33,40 @@ def classify_developability_risk(
     fixability_map: dict[str, str],
     risk_level_map: dict[str, str],
 ) -> str:
-    """Developability risk with a structural override.
+    """Developability risk with two structural overrides.
 
-    Returns 'Non-Developable' when any structural or hard_to_fix liability is
-    present in any region — these candidates cannot be engineered to safety
-    without scaffold redesign, so the column surfaces that fact directly
-    instead of forcing the reader to cross-reference Structural liabilities.
+    Precedence (worst wins):
+      1. structural   → 'Non-Developable' (requires scaffold redesign;
+                       canonical example: Missing Cysteines)
+      2. hard_to_fix  → 'Very High'       (harder than routine engineering
+                       but not non-developable; e.g. Extra Cysteines)
+      3. fixable / easily_fixable → max risk level across those liabilities
+                       only: None / Low / Medium / High
 
-    Otherwise returns the max risk level across fixable + easily_fixable
-    liabilities only (engineering-tractable severity): None / Low / Medium / High.
+    The two overrides fold the Structural liabilities signal into this column
+    so a single column carries both engineering severity and structural
+    disqualification — readers don't need to cross-reference Structural
+    liabilities to see why a candidate is excluded.
 
     Spec deviation: R6 (docs/text/work/projects/sequence-liability-fixability-scoring/README.md:66)
     defined this column as engineering-only with values None/Low/Medium/High.
     Per 2026-05-25 feedback (continuation of the 2026-05-24 Slack thread),
-    the Non-Developable value extends that scale at the top so the column is
-    'wholistic' — one column tells you both whether the candidate is engineerable
-    and how severe the engineering work would be.
+    the scale now extends to {Very High, Non-Developable} at the top.
     """
     risk_order = {"None": 0, "Low": 1, "Medium": 2, "High": 3}
     level_to_risk = {v: k for k, v in risk_order.items()}
+    has_hard_to_fix = False
     current_max = 0
     for liabs_str in region_to_liabs.values():
         for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
             fix = fixability_map.get(name)
-            # Structural override short-circuits the function — Non-Developable
-            # is the worst rank, so no later region can change the answer.
-            if fix in {"structural", "hard_to_fix"}:
+            # Structural is the harshest override — short-circuit immediately
+            # because no later region can change the answer.
+            if fix == "structural":
                 return "Non-Developable"
+            if fix == "hard_to_fix":
+                has_hard_to_fix = True
+                continue  # keep scanning in case a later region has structural
             if fix not in _ENGINEERING_FIXABILITIES:
                 continue
             risk = risk_level_map.get(name)
@@ -67,6 +74,8 @@ def classify_developability_risk(
                 level = risk_order.get(risk, 0)
                 if level > current_max:
                     current_max = level
+    if has_hard_to_fix:
+        return "Very High"
     return level_to_risk[current_max]
 
 

--- a/liabilities-calc-script/src/scoring.py
+++ b/liabilities-calc-script/src/scoring.py
@@ -1,6 +1,6 @@
 import re
 
-from definitions import FIXABILITY_WEIGHTS, REGION_WEIGHTS, _ENGINEERING_FIXABILITIES
+from definitions import _ENGINEERING_FIXABILITIES, FIXABILITY_WEIGHTS, REGION_WEIGHTS
 
 
 def _parse_liability_names(liabs_str: str) -> list[str]:
@@ -33,7 +33,29 @@ def classify_developability_risk(
     fixability_map: dict[str, str],
     risk_level_map: dict[str, str],
 ) -> str:
-    """Max risk level across fixable and easily_fixable liabilities only."""
+    """Developability risk with a structural override.
+
+    Returns 'Non-Developable' when any structural or hard_to_fix liability is
+    present in any region — these candidates cannot be engineered to safety
+    without scaffold redesign, so the column surfaces that fact directly
+    instead of forcing the reader to cross-reference Structural liabilities.
+
+    Otherwise returns the max risk level across fixable + easily_fixable
+    liabilities only (engineering-tractable severity): None / Low / Medium / High.
+
+    Spec deviation: R6 (docs/text/work/projects/sequence-liability-fixability-scoring/README.md:66)
+    defined this column as engineering-only with values None/Low/Medium/High.
+    Per 2026-05-25 feedback (continuation of the 2026-05-24 Slack thread),
+    the Non-Developable value extends that scale at the top so the column is
+    'wholistic' — one column tells you both whether the candidate is engineerable
+    and how severe the engineering work would be.
+    """
+    # Structural override takes precedence over engineering-risk levels.
+    for liabs_str in region_to_liabs.values():
+        for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
+            if fixability_map.get(name) in {"structural", "hard_to_fix"}:
+                return "Non-Developable"
+
     risk_order = {"None": 0, "Low": 1, "Medium": 2, "High": 3}
     level_to_risk = {v: k for k, v in risk_order.items()}
     current_max = 0

--- a/liabilities-calc-script/src/scoring.py
+++ b/liabilities-calc-script/src/scoring.py
@@ -50,26 +50,23 @@ def classify_developability_risk(
     'wholistic' — one column tells you both whether the candidate is engineerable
     and how severe the engineering work would be.
     """
-    # Structural override takes precedence over engineering-risk levels.
-    for liabs_str in region_to_liabs.values():
-        for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
-            if fixability_map.get(name) in {"structural", "hard_to_fix"}:
-                return "Non-Developable"
-
     risk_order = {"None": 0, "Low": 1, "Medium": 2, "High": 3}
     level_to_risk = {v: k for k, v in risk_order.items()}
     current_max = 0
     for liabs_str in region_to_liabs.values():
         for name in _parse_liability_names(str(liabs_str) if liabs_str else "None"):
-            if fixability_map.get(name) not in _ENGINEERING_FIXABILITIES:
+            fix = fixability_map.get(name)
+            # Structural override short-circuits the function — Non-Developable
+            # is the worst rank, so no later region can change the answer.
+            if fix in {"structural", "hard_to_fix"}:
+                return "Non-Developable"
+            if fix not in _ENGINEERING_FIXABILITIES:
                 continue
             risk = risk_level_map.get(name)
             if risk:
                 level = risk_order.get(risk, 0)
                 if level > current_max:
                     current_max = level
-                if current_max == 3:
-                    return "High"
     return level_to_risk[current_max]
 
 

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -320,13 +320,19 @@ def test_custom_liability_restricted_to_fr1(tmp_path):
     """A custom liability targeting FR1 only is detected there but not in CDRs."""
     custom = tmp_path / "custom.json"
     # FR1 for all test clones contains 'P' (e.g. QVQLVQSGAEVKKPGASVKVSCKAS)
-    custom.write_text(json.dumps([{
-        "name": "FR1 Proline",
-        "pattern": "P",
-        "riskLevel": "Low",
-        "fixability": "fixable",
-        "regions": ["FR1"],
-    }]))
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "FR1 Proline",
+                    "pattern": "P",
+                    "riskLevel": "Low",
+                    "fixability": "fixable",
+                    "regions": ["FR1"],
+                }
+            ]
+        )
+    )
     df = run_main(tmp_path, ["--custom-liabilities", str(custom)])
     r = row(df, "clone_clean")
     assert "FR1 Proline" in r["FR1 aa liabilities"]
@@ -438,76 +444,47 @@ def test_sc_both_chains_liabilities(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Custom liability per-region risk
+# Per-region risk by liability class
 #
-# Custom fixable/easily_fixable liabilities must appear in per-region risk
-# columns, not only in global developability columns.
+# The spec at :126 (Open Questions) named two options for per-region risk:
+# (A) fixable + easily_fixable only, or (B) all liabilities except disqualifying.
+# The v4.0.0 implementor picked A and encoded it across R8 :71, Step 2 :252-253,
+# Defaults :304, M1 :346, and Risks :395. User feedback (Slack 2026-05-24)
+# revealed Option A's predicted counter-argument materialized — per-region
+# Liabilities and Risk visibly disagree. These tests lock in the switch to
+# Option B: per-region risk is the max riskLevel of any non-disqualifying
+# liability in the region, regardless of fixability class.
 # ---------------------------------------------------------------------------
 
 
-def test_custom_fixable_liability_raises_per_region_risk(tmp_path):
-    """A High-risk fixable custom liability in CDR3 must produce High per-region risk for CDR3.
-
-    Regression: classify_risk() previously ignored custom liabilities, leaving
-    CDR3 aa risk at None even when a custom fixable liability was detected there.
+@pytest.mark.parametrize(
+    "fixability, pattern, region, clone, expected_risk, expected_structural",
+    [
+        ("easily_fixable", "GR", "CDR2", "clone_clean", "Medium", "None"),
+        ("fixable", "WW", "CDR3", "clone_custom_ww", "High", "None"),
+        ("hard_to_fix", "WW", "CDR3", "clone_custom_ww", "High", "Present"),
+    ],
+    ids=["easily_fixable-cdr2-medium", "fixable-cdr3-high", "hard_to_fix-cdr3-high"],
+)
+def test_custom_liability_per_region_risk_by_fixability(
+    tmp_path, fixability, pattern, region, clone, expected_risk, expected_structural
+):
+    """A custom liability's riskLevel surfaces in {region} aa risk regardless of
+    fixability class (Option B at spec :126). The Structural liabilities column
+    additionally flags Present for hard_to_fix/structural matches; engineering-
+    only fixabilities (fixable, easily_fixable) leave it None.
     """
-    custom = tmp_path / "custom.json"
-    custom.write_text(json.dumps([{
-        "name": "WW motif",
-        "pattern": "WW",
-        "riskLevel": "High",
-        "fixability": "fixable",
-        "regions": ["CDR3"],
-    }]))
-    df = run_main(
-        tmp_path,
-        ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],
-    )
-    r = row(df, "clone_custom_ww")
-    # WW is present in CDR3 — per-region risk must reflect it
-    assert r["CDR3 aa risk"] == "High"
-    # CDR2 has no WW — must remain None
-    assert r["CDR2 aa risk"] == "None"
-
-
-def test_custom_easily_fixable_liability_raises_per_region_risk(tmp_path):
-    """A Medium easily_fixable custom liability in CDR2 must raise CDR2 aa risk to Medium."""
-    custom = tmp_path / "custom.json"
-    custom.write_text(json.dumps([{
-        "name": "GR motif",
-        "pattern": "GR",
-        "riskLevel": "Medium",
-        "fixability": "easily_fixable",
-        "regions": ["CDR2"],
-    }]))
-    df = run_main(
-        tmp_path,
-        ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],
-    )
-    # clone_clean CDR2 = ISPGRGIT — contains GR
-    r = row(df, "clone_clean")
-    assert r["CDR2 aa risk"] == "Medium"
-    # CDR3 has no GR — must stay None
-    assert r["CDR3 aa risk"] == "None"
-
-
-def test_custom_hard_to_fix_raises_per_region_risk_and_structural_present(tmp_path):
-    """A hard_to_fix custom liability flags BOTH the per-region risk AND
-    Structural liabilities. Previously, per the original Option-A choice (see
-    spec :126 Open Questions), only Structural was flagged; per-region risk
-    was suppressed. User feedback (Slack 2026-05-24) reversed the call —
-    per-region risk now includes hard_to_fix matches.
-    """
+    liability_name = f"Custom {fixability}"
     custom = tmp_path / "custom.json"
     custom.write_text(
         json.dumps(
             [
                 {
-                    "name": "WW hard",
-                    "pattern": "WW",
-                    "riskLevel": "High",
-                    "fixability": "hard_to_fix",
-                    "regions": ["CDR3"],
+                    "name": liability_name,
+                    "pattern": pattern,
+                    "riskLevel": expected_risk,
+                    "fixability": fixability,
+                    "regions": [region],
                 }
             ]
         )
@@ -516,45 +493,63 @@ def test_custom_hard_to_fix_raises_per_region_risk_and_structural_present(tmp_pa
         tmp_path,
         ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],
     )
-    r = row(df, "clone_custom_ww")
-    assert r["Structural liabilities"] == "Present"
-    assert r["CDR3 aa risk"] == "High"
+    r = row(df, clone)
+    assert liability_name in r[f"{region} aa liabilities"]
+    assert r[f"{region} aa risk"] == expected_risk
+    # Custom liability is scoped to one region — other CDRs stay None.
+    for other_region in ("CDR1", "CDR2", "CDR3"):
+        if other_region != region:
+            assert r[f"{other_region} aa risk"] == "None"
+    assert r["Structural liabilities"] == expected_structural
 
 
-def test_custom_and_predefined_combine_in_per_region_risk(tmp_path):
-    """Custom and predefined fixable liabilities in the same region take the higher risk level.
+@pytest.mark.parametrize(
+    "custom_name, pattern, custom_fixability",
+    [
+        ("MG motif", "MG", "fixable"),
+        ("Custom hard M", "M", "hard_to_fix"),
+    ],
+    ids=["custom-fixable-high", "custom-hard_to_fix-high"],
+)
+def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
+    tmp_path, custom_name, pattern, custom_fixability
+):
+    """Per-region risk takes the max across all non-disqualifying liabilities in
+    the region. clone_met_cdr3 CDR3 has predefined Methionine Oxidation
+    (Medium/easily_fixable); adding a custom High in the same region must raise
+    CDR3 risk to High.
 
-    clone_met_cdr3 CDR3 has Met (predefined Medium/easily_fixable).
-    Adding a custom High/fixable motif that also matches CDR3 must raise it to High.
+    Cases:
+    - custom-fixable-high: Option A already produced High here (both items
+      counted toward engineering risk). Confirms behavior is unchanged.
+    - custom-hard_to_fix-high: under Option A the custom was excluded so CDR3
+      risk stayed at Medium. Under Option B it now contributes; CDR3 → High.
     """
     custom = tmp_path / "custom.json"
-    custom.write_text(json.dumps([{
-        "name": "MG motif",
-        "pattern": "MG",
-        "riskLevel": "High",
-        "fixability": "fixable",
-        "regions": ["CDR3"],
-    }]))
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": custom_name,
+                    "pattern": pattern,
+                    "riskLevel": "High",
+                    "fixability": custom_fixability,
+                    "regions": ["CDR3"],
+                }
+            ]
+        )
+    )
     df = run_main(tmp_path, ["--custom-liabilities", str(custom)])
     r = row(df, "clone_met_cdr3")
-    # Custom MG (High) beats predefined Met (Medium) — CDR3 risk must be High
+    assert "Methionine Oxidation (M)" in r["CDR3 aa liabilities"]
+    assert custom_name in r["CDR3 aa liabilities"]
     assert r["CDR3 aa risk"] == "High"
-
-
-# ---------------------------------------------------------------------------
-# Per-region risk: hard_to_fix / structural liabilities surface in {region} aa risk
-#
-# The original fixability-aware design (spec :126 Open Questions named both
-# options; R8 :71 / Step 2 :252-253 / Defaults :304 / M1 :346 / Risks :395
-# encoded Option A: fixable + easily_fixable only). User feedback (Slack
-# 2026-05-24) revealed Option A's counter-argument from spec :126 had
-# materialized — per-region Liabilities and Risk visibly disagree. These
-# tests lock in the switch to Option B (all liabilities except disqualifying).
-# ---------------------------------------------------------------------------
 
 
 def test_extra_cys_raises_per_region_risk(tmp_path):
-    """Extra Cysteines (predefined hard_to_fix, High) in CDR3 must yield CDR3 aa risk = High."""
+    """Extra Cysteines (predefined hard_to_fix, High) in CDR3 must yield CDR3
+    aa risk = High. Predefined counterpart to the hard_to_fix custom-liability
+    cases in test_custom_liability_per_region_risk_by_fixability."""
     df = run_main(tmp_path)
     r = row(df, "clone_extra_cys")
     assert "Extra Cysteines" in r["CDR3 aa liabilities"]
@@ -565,61 +560,29 @@ def test_extra_cys_raises_per_region_risk(tmp_path):
     assert r["Developability risk"] == "None"
 
 
-def test_custom_hard_to_fix_raises_per_region_risk(tmp_path):
-    """A hard_to_fix custom liability with riskLevel=High must flag CDR3 aa risk = High.
-
-    Regression for the 2026-05-24 bug: setting fixability=Hard to fix on a
-    custom liability previously left per-region risk at None even when the
-    pattern matched. The user-facing expectation is that riskLevel is honored
-    in the per-region risk column regardless of fixability class.
-    """
-    custom = tmp_path / "custom.json"
-    custom.write_text(
-        json.dumps(
-            [
-                {
-                    "name": "WW hard",
-                    "pattern": "WW",
-                    "riskLevel": "High",
-                    "fixability": "hard_to_fix",
-                    "regions": ["CDR3"],
-                }
-            ]
-        )
-    )
-    df = run_main(
-        tmp_path,
-        ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],
-    )
-    r = row(df, "clone_custom_ww")
-    assert "WW hard" in r["CDR3 aa liabilities"]
-    assert r["CDR3 aa risk"] == "High"
-    # Other regions stay None (no match there).
-    assert r["CDR1 aa risk"] == "None"
-    assert r["CDR2 aa risk"] == "None"
-    # Structural liabilities still flags it (hard_to_fix routes there too).
+def test_missing_cys_raises_fr1_per_region_risk(tmp_path):
+    """Missing Cysteines (predefined structural, High) in FR1 must yield FR1
+    aa risk = High. Covers the 'structural' fixability class — symmetric to
+    test_extra_cys_raises_per_region_risk which covers 'hard_to_fix'."""
+    df = run_main(tmp_path)
+    r = row(df, "clone_missing_cys")
+    assert "Missing Cysteines" in r["FR1 aa liabilities"]
+    assert r["FR1 aa risk"] == "High"
     assert r["Structural liabilities"] == "Present"
+    # Developability risk stays None (engineering-only column).
+    assert r["Developability risk"] == "None"
 
 
-def test_custom_hard_to_fix_high_overrides_easily_fixable_medium_in_same_region(tmp_path):
-    """When both an easily_fixable Medium (predefined Met) and a hard_to_fix High
-    (custom) match the same region, per-region risk takes the max → High."""
-    custom = tmp_path / "custom.json"
-    # clone_met_cdr3 CDR3 contains 'M' (predefined Met oxidation, Medium/easily_fixable).
-    # Add a hard_to_fix High custom that also matches CDR3 'M'.
-    custom.write_text(
-        json.dumps(
-            [
-                {
-                    "name": "Custom hard M",
-                    "pattern": "M",
-                    "riskLevel": "High",
-                    "fixability": "hard_to_fix",
-                    "regions": ["CDR3"],
-                }
-            ]
-        )
-    )
-    df = run_main(tmp_path, ["--custom-liabilities", str(custom)])
-    r = row(df, "clone_met_cdr3")
-    assert r["CDR3 aa risk"] == "High"
+def test_stop_codon_does_not_raise_per_region_risk(tmp_path):
+    """A disqualifying liability (stop codon) in a region's liabilities string
+    must NOT contribute to per-region risk for that region. clone_stop has the
+    stop codon in CDR1; CDR1 aa risk must stay None even though
+    "Contains stop codon" is listed in CDR1 aa liabilities. The disqualifying
+    signal surfaces via Is Productive = Fail.
+
+    Guards the 'disqualifying' skip in classify_risk()."""
+    df = run_main(tmp_path)
+    r = row(df, "clone_stop")
+    assert "Contains stop codon" in r["CDR1 aa liabilities"]
+    assert r["CDR1 aa risk"] == "None"
+    assert r["Is Productive"] == "Fail"

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -87,7 +87,8 @@ def test_missing_cys_is_structural(tmp_path):
     r = row(df, "clone_missing_cys")
     assert r["Is Productive"] == "Pass"
     assert r["Structural liabilities"] == "Present"
-    assert r["Developability risk"] == "None"
+    # Structural override: any structural / hard_to_fix → Developability risk = Non-Developable.
+    assert r["Developability risk"] == "Non-Developable"
     # FR1 weight=1.0, structural fixability_weight=20.0
     assert r["Developability cost"] == pytest.approx(20.0)
 
@@ -97,7 +98,8 @@ def test_extra_cys_is_structural(tmp_path):
     r = row(df, "clone_extra_cys")
     assert r["Is Productive"] == "Pass"
     assert r["Structural liabilities"] == "Present"
-    assert r["Developability risk"] == "None"
+    # Structural override: any structural / hard_to_fix → Developability risk = Non-Developable.
+    assert r["Developability risk"] == "Non-Developable"
     # CDR3 weight=1.5, hard_to_fix fixability_weight=8.0
     assert r["Developability cost"] == pytest.approx(12.0)
 
@@ -458,21 +460,30 @@ def test_sc_both_chains_liabilities(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "fixability, pattern, region, clone, expected_risk, expected_structural",
+    "fixability, pattern, region, clone, expected_risk, expected_structural, expected_devel_risk",
     [
-        ("easily_fixable", "GR", "CDR2", "clone_clean", "Medium", "None"),
-        ("fixable", "WW", "CDR3", "clone_custom_ww", "High", "None"),
-        ("hard_to_fix", "WW", "CDR3", "clone_custom_ww", "High", "Present"),
+        ("easily_fixable", "GR", "CDR2", "clone_clean", "Medium", "None", "Medium"),
+        ("fixable", "WW", "CDR3", "clone_custom_ww", "High", "None", "High"),
+        ("hard_to_fix", "WW", "CDR3", "clone_custom_ww", "High", "Present", "Non-Developable"),
     ],
     ids=["easily_fixable-cdr2-medium", "fixable-cdr3-high", "hard_to_fix-cdr3-high"],
 )
 def test_custom_liability_per_region_risk_by_fixability(
-    tmp_path, fixability, pattern, region, clone, expected_risk, expected_structural
+    tmp_path,
+    fixability,
+    pattern,
+    region,
+    clone,
+    expected_risk,
+    expected_structural,
+    expected_devel_risk,
 ):
     """A custom liability's riskLevel surfaces in {region} aa risk regardless of
     fixability class (Option B at spec :126). The Structural liabilities column
     additionally flags Present for hard_to_fix/structural matches; engineering-
-    only fixabilities (fixable, easily_fixable) leave it None.
+    only fixabilities (fixable, easily_fixable) leave it None. Developability
+    risk reflects the engineering severity (None/Low/Medium/High) for engineering-
+    only fixabilities, and switches to Non-Developable when Structural = Present.
     """
     liability_name = f"Custom {fixability}"
     custom = tmp_path / "custom.json"
@@ -501,29 +512,33 @@ def test_custom_liability_per_region_risk_by_fixability(
         if other_region != region:
             assert r[f"{other_region} aa risk"] == "None"
     assert r["Structural liabilities"] == expected_structural
+    assert r["Developability risk"] == expected_devel_risk
 
 
 @pytest.mark.parametrize(
-    "custom_name, pattern, custom_fixability",
+    "custom_name, pattern, custom_fixability, expected_devel_risk",
     [
-        ("MG motif", "MG", "fixable"),
-        ("Custom hard M", "M", "hard_to_fix"),
+        ("MG motif", "MG", "fixable", "High"),
+        ("Custom hard M", "M", "hard_to_fix", "Non-Developable"),
     ],
     ids=["custom-fixable-high", "custom-hard_to_fix-high"],
 )
 def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
-    tmp_path, custom_name, pattern, custom_fixability
+    tmp_path, custom_name, pattern, custom_fixability, expected_devel_risk
 ):
     """Per-region risk takes the max across all non-disqualifying liabilities in
     the region. clone_met_cdr3 CDR3 has predefined Methionine Oxidation
     (Medium/easily_fixable); adding a custom High in the same region must raise
-    CDR3 risk to High.
+    CDR3 risk to High. Developability risk also depends on the custom's class:
+    fixable contributes to engineering severity (High); hard_to_fix triggers the
+    structural override (Non-Developable).
 
     Cases:
     - custom-fixable-high: Option A already produced High here (both items
       counted toward engineering risk). Confirms behavior is unchanged.
     - custom-hard_to_fix-high: under Option A the custom was excluded so CDR3
       risk stayed at Medium. Under Option B it now contributes; CDR3 → High.
+      The hard_to_fix class also flips Developability risk to Non-Developable.
     """
     custom = tmp_path / "custom.json"
     custom.write_text(
@@ -544,6 +559,7 @@ def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
     assert "Methionine Oxidation (M)" in r["CDR3 aa liabilities"]
     assert custom_name in r["CDR3 aa liabilities"]
     assert r["CDR3 aa risk"] == "High"
+    assert r["Developability risk"] == expected_devel_risk
 
 
 def test_extra_cys_raises_per_region_risk(tmp_path):
@@ -554,10 +570,10 @@ def test_extra_cys_raises_per_region_risk(tmp_path):
     r = row(df, "clone_extra_cys")
     assert "Extra Cysteines" in r["CDR3 aa liabilities"]
     assert r["CDR3 aa risk"] == "High"
-    # Structural liabilities column still flags Present (unchanged).
+    # Structural liabilities column still flags Present.
     assert r["Structural liabilities"] == "Present"
-    # Developability risk stays None (engineering-only column, unchanged).
-    assert r["Developability risk"] == "None"
+    # Structural override: Developability risk reports Non-Developable.
+    assert r["Developability risk"] == "Non-Developable"
 
 
 def test_missing_cys_raises_fr1_per_region_risk(tmp_path):
@@ -569,8 +585,8 @@ def test_missing_cys_raises_fr1_per_region_risk(tmp_path):
     assert "Missing Cysteines" in r["FR1 aa liabilities"]
     assert r["FR1 aa risk"] == "High"
     assert r["Structural liabilities"] == "Present"
-    # Developability risk stays None (engineering-only column).
-    assert r["Developability risk"] == "None"
+    # Structural override: Developability risk reports Non-Developable.
+    assert r["Developability risk"] == "Non-Developable"
 
 
 def test_stop_codon_does_not_raise_per_region_risk(tmp_path):

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -528,3 +528,87 @@ def test_custom_and_predefined_combine_in_per_region_risk(tmp_path):
     r = row(df, "clone_met_cdr3")
     # Custom MG (High) beats predefined Met (Medium) — CDR3 risk must be High
     assert r["CDR3 aa risk"] == "High"
+
+
+# ---------------------------------------------------------------------------
+# Per-region risk: hard_to_fix / structural liabilities surface in {region} aa risk
+#
+# The original fixability-aware design (spec :126 Open Questions named both
+# options; R8 :71 / Step 2 :252-253 / Defaults :304 / M1 :346 / Risks :395
+# encoded Option A: fixable + easily_fixable only). User feedback (Slack
+# 2026-05-24) revealed Option A's counter-argument from spec :126 had
+# materialized — per-region Liabilities and Risk visibly disagree. These
+# tests lock in the switch to Option B (all liabilities except disqualifying).
+# ---------------------------------------------------------------------------
+
+
+def test_extra_cys_raises_per_region_risk(tmp_path):
+    """Extra Cysteines (predefined hard_to_fix, High) in CDR3 must yield CDR3 aa risk = High."""
+    df = run_main(tmp_path)
+    r = row(df, "clone_extra_cys")
+    assert "Extra Cysteines" in r["CDR3 aa liabilities"]
+    assert r["CDR3 aa risk"] == "High"
+    # Structural liabilities column still flags Present (unchanged).
+    assert r["Structural liabilities"] == "Present"
+    # Developability risk stays None (engineering-only column, unchanged).
+    assert r["Developability risk"] == "None"
+
+
+def test_custom_hard_to_fix_raises_per_region_risk(tmp_path):
+    """A hard_to_fix custom liability with riskLevel=High must flag CDR3 aa risk = High.
+
+    Regression for the 2026-05-24 bug: setting fixability=Hard to fix on a
+    custom liability previously left per-region risk at None even when the
+    pattern matched. The user-facing expectation is that riskLevel is honored
+    in the per-region risk column regardless of fixability class.
+    """
+    custom = tmp_path / "custom.json"
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "WW hard",
+                    "pattern": "WW",
+                    "riskLevel": "High",
+                    "fixability": "hard_to_fix",
+                    "regions": ["CDR3"],
+                }
+            ]
+        )
+    )
+    df = run_main(
+        tmp_path,
+        ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],
+    )
+    r = row(df, "clone_custom_ww")
+    assert "WW hard" in r["CDR3 aa liabilities"]
+    assert r["CDR3 aa risk"] == "High"
+    # Other regions stay None (no match there).
+    assert r["CDR1 aa risk"] == "None"
+    assert r["CDR2 aa risk"] == "None"
+    # Structural liabilities still flags it (hard_to_fix routes there too).
+    assert r["Structural liabilities"] == "Present"
+
+
+def test_custom_hard_to_fix_high_overrides_easily_fixable_medium_in_same_region(tmp_path):
+    """When both an easily_fixable Medium (predefined Met) and a hard_to_fix High
+    (custom) match the same region, per-region risk takes the max → High."""
+    custom = tmp_path / "custom.json"
+    # clone_met_cdr3 CDR3 contains 'M' (predefined Met oxidation, Medium/easily_fixable).
+    # Add a hard_to_fix High custom that also matches CDR3 'M'.
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "Custom hard M",
+                    "pattern": "M",
+                    "riskLevel": "High",
+                    "fixability": "hard_to_fix",
+                    "regions": ["CDR3"],
+                }
+            ]
+        )
+    )
+    df = run_main(tmp_path, ["--custom-liabilities", str(custom)])
+    r = row(df, "clone_met_cdr3")
+    assert r["CDR3 aa risk"] == "High"

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -87,7 +87,7 @@ def test_missing_cys_is_structural(tmp_path):
     r = row(df, "clone_missing_cys")
     assert r["Is Productive"] == "Pass"
     assert r["Structural liabilities"] == "Present"
-    # Structural override: any structural / hard_to_fix → Developability risk = Non-Developable.
+    # Structural override: Missing Cys is 'structural' fixability → Non-Developable.
     assert r["Developability risk"] == "Non-Developable"
     # FR1 weight=1.0, structural fixability_weight=20.0
     assert r["Developability cost"] == pytest.approx(20.0)
@@ -98,8 +98,9 @@ def test_extra_cys_is_structural(tmp_path):
     r = row(df, "clone_extra_cys")
     assert r["Is Productive"] == "Pass"
     assert r["Structural liabilities"] == "Present"
-    # Structural override: any structural / hard_to_fix → Developability risk = Non-Developable.
-    assert r["Developability risk"] == "Non-Developable"
+    # hard_to_fix override: Developability risk = Very High (structural class
+    # would be Non-Developable; Extra Cys is hard_to_fix, the milder bucket).
+    assert r["Developability risk"] == "Very High"
     # CDR3 weight=1.5, hard_to_fix fixability_weight=8.0
     assert r["Developability cost"] == pytest.approx(12.0)
 
@@ -464,9 +465,9 @@ def test_sc_both_chains_liabilities(tmp_path):
     [
         ("easily_fixable", "GR", "CDR2", "clone_clean", "Medium", "None", "Medium"),
         ("fixable", "WW", "CDR3", "clone_custom_ww", "High", "None", "High"),
-        ("hard_to_fix", "WW", "CDR3", "clone_custom_ww", "High", "Present", "Non-Developable"),
+        ("hard_to_fix", "WW", "CDR3", "clone_custom_ww", "High", "Present", "Very High"),
     ],
-    ids=["easily_fixable-cdr2-medium", "fixable-cdr3-high", "hard_to_fix-cdr3-high"],
+    ids=["easily_fixable-cdr2-medium", "fixable-cdr3-high", "hard_to_fix-cdr3-veryhigh"],
 )
 def test_custom_liability_per_region_risk_by_fixability(
     tmp_path,
@@ -519,9 +520,9 @@ def test_custom_liability_per_region_risk_by_fixability(
     "custom_name, pattern, custom_fixability, expected_devel_risk",
     [
         ("MG motif", "MG", "fixable", "High"),
-        ("Custom hard M", "M", "hard_to_fix", "Non-Developable"),
+        ("Custom hard M", "M", "hard_to_fix", "Very High"),
     ],
-    ids=["custom-fixable-high", "custom-hard_to_fix-high"],
+    ids=["custom-fixable-high", "custom-hard_to_fix-veryhigh"],
 )
 def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
     tmp_path, custom_name, pattern, custom_fixability, expected_devel_risk
@@ -529,16 +530,16 @@ def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
     """Per-region risk takes the max across all non-disqualifying liabilities in
     the region. clone_met_cdr3 CDR3 has predefined Methionine Oxidation
     (Medium/easily_fixable); adding a custom High in the same region must raise
-    CDR3 risk to High. Developability risk also depends on the custom's class:
+    CDR3 risk to High. Developability risk depends on the custom's class:
     fixable contributes to engineering severity (High); hard_to_fix triggers the
-    structural override (Non-Developable).
+    hard_to_fix override (Very High).
 
     Cases:
     - custom-fixable-high: Option A already produced High here (both items
       counted toward engineering risk). Confirms behavior is unchanged.
-    - custom-hard_to_fix-high: under Option A the custom was excluded so CDR3
-      risk stayed at Medium. Under Option B it now contributes; CDR3 → High.
-      The hard_to_fix class also flips Developability risk to Non-Developable.
+    - custom-hard_to_fix-veryhigh: under Option A the custom was excluded so
+      CDR3 risk stayed at Medium. Under Option B it now contributes; CDR3 → High.
+      The hard_to_fix class also flips Developability risk to Very High.
     """
     custom = tmp_path / "custom.json"
     custom.write_text(
@@ -564,28 +565,26 @@ def test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region(
 
 def test_extra_cys_raises_per_region_risk(tmp_path):
     """Extra Cysteines (predefined hard_to_fix, High) in CDR3 must yield CDR3
-    aa risk = High. Predefined counterpart to the hard_to_fix custom-liability
-    cases in test_custom_liability_per_region_risk_by_fixability."""
+    aa risk = High and Developability risk = Very High (hard_to_fix override —
+    the milder of the two structural-class overrides)."""
     df = run_main(tmp_path)
     r = row(df, "clone_extra_cys")
     assert "Extra Cysteines" in r["CDR3 aa liabilities"]
     assert r["CDR3 aa risk"] == "High"
-    # Structural liabilities column still flags Present.
     assert r["Structural liabilities"] == "Present"
-    # Structural override: Developability risk reports Non-Developable.
-    assert r["Developability risk"] == "Non-Developable"
+    assert r["Developability risk"] == "Very High"
 
 
 def test_missing_cys_raises_fr1_per_region_risk(tmp_path):
     """Missing Cysteines (predefined structural, High) in FR1 must yield FR1
-    aa risk = High. Covers the 'structural' fixability class — symmetric to
-    test_extra_cys_raises_per_region_risk which covers 'hard_to_fix'."""
+    aa risk = High and Developability risk = Non-Developable (structural
+    override — the harshest bucket). Symmetric to
+    test_extra_cys_raises_per_region_risk which covers 'hard_to_fix' → Very High."""
     df = run_main(tmp_path)
     r = row(df, "clone_missing_cys")
     assert "Missing Cysteines" in r["FR1 aa liabilities"]
     assert r["FR1 aa risk"] == "High"
     assert r["Structural liabilities"] == "Present"
-    # Structural override: Developability risk reports Non-Developable.
     assert r["Developability risk"] == "Non-Developable"
 
 
@@ -602,3 +601,39 @@ def test_stop_codon_does_not_raise_per_region_risk(tmp_path):
     assert "Contains stop codon" in r["CDR1 aa liabilities"]
     assert r["CDR1 aa risk"] == "None"
     assert r["Is Productive"] == "Fail"
+
+
+def test_structural_supersedes_hard_to_fix_in_developability_risk(tmp_path):
+    """When a row carries BOTH a structural and a hard_to_fix liability,
+    Developability risk reports Non-Developable. The harsher override wins.
+
+    Setup: clone_extra_cys already has predefined Extra Cysteines (hard_to_fix)
+    in CDR3 — alone that yields Developability risk = Very High. Adding a custom
+    'structural' liability matching CDR1 must override to Non-Developable.
+
+    Note: the UI restricts custom fixability to {easily_fixable, fixable,
+    hard_to_fix}. 'structural' is used here via direct JSON to exercise the
+    override-precedence rule; production users reach this state only through
+    the predefined Missing Cysteines liability.
+    """
+    custom = tmp_path / "custom.json"
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "Custom structural",
+                    "pattern": "[A-Z]",
+                    "riskLevel": "High",
+                    "fixability": "structural",
+                    "regions": ["CDR1"],
+                }
+            ]
+        )
+    )
+    df = run_main(tmp_path, ["--custom-liabilities", str(custom)])
+    r = row(df, "clone_extra_cys")
+    assert "Extra Cysteines" in r["CDR3 aa liabilities"]
+    assert "Custom structural" in r["CDR1 aa liabilities"]
+    # hard_to_fix alone → Very High; structural wins → Non-Developable.
+    assert r["Developability risk"] == "Non-Developable"
+    assert r["Structural liabilities"] == "Present"

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -499,13 +499,19 @@ def test_custom_hard_to_fix_raises_per_region_risk_and_structural_present(tmp_pa
     per-region risk now includes hard_to_fix matches.
     """
     custom = tmp_path / "custom.json"
-    custom.write_text(json.dumps([{
-        "name": "WW hard",
-        "pattern": "WW",
-        "riskLevel": "High",
-        "fixability": "hard_to_fix",
-        "regions": ["CDR3"],
-    }]))
+    custom.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "WW hard",
+                    "pattern": "WW",
+                    "riskLevel": "High",
+                    "fixability": "hard_to_fix",
+                    "regions": ["CDR3"],
+                }
+            ]
+        )
+    )
     df = run_main(
         tmp_path,
         ["--use-predefined-liabilities", "false", "--custom-liabilities", str(custom)],

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -491,8 +491,13 @@ def test_custom_easily_fixable_liability_raises_per_region_risk(tmp_path):
     assert r["CDR3 aa risk"] == "None"
 
 
-def test_custom_hard_to_fix_does_not_raise_per_region_risk(tmp_path):
-    """A hard_to_fix custom liability routes to Structural liabilities, not per-region risk."""
+def test_custom_hard_to_fix_raises_per_region_risk_and_structural_present(tmp_path):
+    """A hard_to_fix custom liability flags BOTH the per-region risk AND
+    Structural liabilities. Previously, per the original Option-A choice (see
+    spec :126 Open Questions), only Structural was flagged; per-region risk
+    was suppressed. User feedback (Slack 2026-05-24) reversed the call —
+    per-region risk now includes hard_to_fix matches.
+    """
     custom = tmp_path / "custom.json"
     custom.write_text(json.dumps([{
         "name": "WW hard",
@@ -507,7 +512,7 @@ def test_custom_hard_to_fix_does_not_raise_per_region_risk(tmp_path):
     )
     r = row(df, "clone_custom_ww")
     assert r["Structural liabilities"] == "Present"
-    assert r["CDR3 aa risk"] == "None"
+    assert r["CDR3 aa risk"] == "High"
 
 
 def test_custom_and_predefined_combine_in_per_region_risk(tmp_path):

--- a/liabilities-calc-script/tests/test_integration.py
+++ b/liabilities-calc-script/tests/test_integration.py
@@ -483,8 +483,9 @@ def test_custom_liability_per_region_risk_by_fixability(
     fixability class (Option B at spec :126). The Structural liabilities column
     additionally flags Present for hard_to_fix/structural matches; engineering-
     only fixabilities (fixable, easily_fixable) leave it None. Developability
-    risk reflects the engineering severity (None/Low/Medium/High) for engineering-
-    only fixabilities, and switches to Non-Developable when Structural = Present.
+    risk reflects the engineering severity (None/Low/Medium/High) for
+    engineering-only fixabilities; Very High when hard_to_fix; Non-Developable
+    when structural.
     """
     liability_name = f"Custom {fixability}"
     custom = tmp_path / "custom.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^1.4.9
       version: 1.4.9
     '@platforma-sdk/block-tools':
-      specifier: 2.7.25
-      version: 2.7.25
+      specifier: 2.8.3
+      version: 2.8.3
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
@@ -37,8 +37,8 @@ catalogs:
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.29
-      version: 2.5.29
+      specifier: 3.0.3
+      version: 3.0.3
     '@platforma-sdk/ui-vue':
       specifier: 1.77.0
       version: 1.77.0
@@ -76,7 +76,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.25
+        version: 2.8.3
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -101,7 +101,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.25
+        version: 2.8.3
 
   liabilities-calc-script:
     dependencies:
@@ -130,7 +130,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.25
+        version: 2.8.3
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.28.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.28.0)(typescript@5.6.3))(eslint-plugin-n@17.15.1(eslint@9.28.0))(eslint-plugin-vue@9.32.0(eslint@9.28.0))(eslint@9.28.0)(globals@15.14.0)(typescript-eslint@8.24.0(eslint@9.28.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -195,7 +195,7 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.29
+        version: 3.0.3
 
 packages:
 
@@ -828,8 +828,8 @@ packages:
       '@milaboratories/pl-model-common': 1.36.0
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.5.0':
-    resolution: {integrity: sha512-eVDnXExhKB4DYzqkWD49MYyi6AyBxWyG8WoDMFrB23FjyHgMTR7rSoep0iUsWEoLLGnwq4Qd8l89/hBYpAVg0A==}
+  '@milaboratories/pl-client@3.9.0':
+    resolution: {integrity: sha512-YTVLhS9ZhxQAnPOgChNM23TyzlfNd8WiAHnL9TccbBUMUmHsGhLyH3Ys6bOnGdlO9UKWZFQ+co96m2B9WZxjxw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -838,14 +838,17 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-model-backend@1.2.29':
-    resolution: {integrity: sha512-0jL+k6z6MJha0XMFXq/e814THyvNZZNeBB6zcLYtiWKVYRCKp/iK43xOFCzGAgT1uQVz4AdhKsqgqQv5B9deBw==}
+  '@milaboratories/pl-model-backend@1.3.3':
+    resolution: {integrity: sha512-lXOLgKjgteuDnOgf3CMrT13TdD4z36CC8Lail1nvlHKF+ZDbd+nNvsCbIQ5UA/AUVQCd3ucGOacgX2soc/+TyQ==}
 
   '@milaboratories/pl-model-common@1.42.0':
     resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
   '@milaboratories/pl-model-middle-layer@1.19.4':
     resolution: {integrity: sha512-2SzgfHmTpSewPAv3WqbS6XHpObh69Mull3b1ec2bhn11ij6zSEDcBrMz0fFQ1XViAVQcafC4CjNTDZ/6s92kgQ==}
+
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
   '@milaboratories/ptabler-expression-js@1.2.25':
     resolution: {integrity: sha512-dFx+gNoDssA7dQZTr0y93TWuNwlyNY9tzvUaeH0F7BYu/03ZzyLZ4N2iM7ai44bisqAe9o0ppmNM9LtoeTn5Gg==}
@@ -1113,8 +1116,8 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
-  '@platforma-sdk/block-tools@2.7.25':
-    resolution: {integrity: sha512-7msHgkgr3uFTitgokcOFAqdO9mtAUr9rHnmjk26WzIzO1HY/uyrs2AHWpdc/skchJHr1U7HHzNt7oQ3RdzZWpQ==}
+  '@platforma-sdk/block-tools@2.8.3':
+    resolution: {integrity: sha512-0wAjpHoW6MCecgEh9PinE9lSAjcYBEJgQx1qWTBpPXZKqtLrZy27pamEHQY+mlV/OMa72HDZMy+1eeY53FMQpg==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1140,8 +1143,8 @@ packages:
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.29':
-    resolution: {integrity: sha512-iurwyuFCq1DynPuoud182Ebdrk8dhSjLddkOSvPQb1QZ+HVU/CcEfIx0SgZ+qOLstHQ1lB2YeHv7GCaMHsjI9A==}
+  '@platforma-sdk/tengo-builder@3.0.3':
+    resolution: {integrity: sha512-I0zv1iy0UaiShkMGXBZIyB3DnhI6qo8GE9oDzdj0Eql+tESLOGr4iD30UFddW2b68AR6zpsqdREa9OxfGuKgxQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3832,6 +3835,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -5084,7 +5088,7 @@ snapshots:
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.19.4
 
-  '@milaboratories/pl-client@3.5.0':
+  '@milaboratories/pl-client@3.9.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -5111,9 +5115,9 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-model-backend@1.2.29':
+  '@milaboratories/pl-model-backend@1.3.3':
     dependencies:
-      '@milaboratories/pl-client': 3.5.0
+      '@milaboratories/pl-client': 3.9.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -5125,6 +5129,14 @@ snapshots:
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.19.4':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
+      es-toolkit: 1.39.10
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
@@ -5153,7 +5165,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.18
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -5193,7 +5205,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.18
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -5441,12 +5453,13 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.7.25':
+  '@platforma-sdk/block-tools@2.8.3':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.3.3
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@milaboratories/ts-helpers-oclif': 1.1.41
@@ -5506,9 +5519,9 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.5.29':
+  '@platforma-sdk/tengo-builder@3.0.3':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.29
+      '@milaboratories/pl-model-backend': 1.3.3
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2
@@ -7936,7 +7949,7 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.18)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,9 @@ catalog:
   '@platforma-sdk/workflow-tengo': 5.24.0
   '@platforma-sdk/model': 1.77.0
   '@platforma-sdk/ui-vue': 1.77.0
-  '@platforma-sdk/tengo-builder': 2.5.29
+  '@platforma-sdk/tengo-builder': 3.0.3
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.25
+  '@platforma-sdk/block-tools': 2.8.3
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.77.1
   '@milaboratories/helpers': 1.14.2

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -101,7 +101,7 @@ self.body(func(args) {
 				valueType: "String",
 				annotations: {
 					"pl7.app/label": "Developability risk",
-					"pl7.app/description": "Highest risk level across fixable liabilities (deamidation, oxidation, fragmentation, glycosylation). Returns 'Very High' when any hard_to_fix liability is present (e.g. Extra Cysteines) and 'Non-Developable' when any structural liability is present (e.g. Missing Cysteines). A single column carries both engineering severity and structural disqualification. Lead Selection excludes High, Very High, and Non-Developable by default.",
+					"pl7.app/description": "Engineering risk severity for fixable liabilities: None / Low / Medium / High. Very High when a Hard to fix liability is present (e.g. Extra Cysteines). Non-Developable when a Structural liability is present (e.g. Missing Cysteines). Lead Selection keeps None / Low / Medium by default.",
 					"pl7.app/isScore": "true",
 					"pl7.app/isDiscreteFilter": "true",
 					"pl7.app/discreteValues": string(json.encode(["None", "Low", "Medium", "High", "Very High", "Non-Developable"])),

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -81,7 +81,7 @@ self.body(func(args) {
 				valueType: "String",
 				annotations: {
 					"pl7.app/label": "Structural liabilities",
-					"pl7.app/description": "Present when a Structural or Hard to fix liability is found. Duplicates Developability risk's Non-Developable / Very High overrides — hidden by default.",
+					"pl7.app/description": "Present when a Structural or Hard to fix liability is found.",
 					"pl7.app/isScore": "true",
 					"pl7.app/isDiscreteFilter": "true",
 					"pl7.app/discreteValues": string(json.encode(["None", "Present"])),

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -101,10 +101,10 @@ self.body(func(args) {
 				valueType: "String",
 				annotations: {
 					"pl7.app/label": "Developability risk",
-					"pl7.app/description": "Highest risk level across fixable liabilities (deamidation, oxidation, fragmentation, glycosylation). Unlike structural issues, one or two substitutions address these. All risk levels are shown; Lead Selection excludes High by default.",
+					"pl7.app/description": "Highest risk level across fixable liabilities (deamidation, oxidation, fragmentation, glycosylation). Returns 'Non-Developable' when any structural / hard_to_fix liability is present (mirrors Structural liabilities = Present), so a single column carries both engineering severity and structural disqualification. Lead Selection excludes High and Non-Developable by default.",
 					"pl7.app/isScore": "true",
 					"pl7.app/isDiscreteFilter": "true",
-					"pl7.app/discreteValues": string(json.encode(["None", "Low", "Medium", "High"])),
+					"pl7.app/discreteValues": string(json.encode(["None", "Low", "Medium", "High", "Non-Developable"])),
 					"pl7.app/score/rankingOrder": "decreasing",
 					"pl7.app/score/defaultCutoff": string(json.encode(["None", "Low", "Medium"])),
 					"pl7.app/table/visibility": "default",

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -101,10 +101,10 @@ self.body(func(args) {
 				valueType: "String",
 				annotations: {
 					"pl7.app/label": "Developability risk",
-					"pl7.app/description": "Highest risk level across fixable liabilities (deamidation, oxidation, fragmentation, glycosylation). Returns 'Non-Developable' when any structural / hard_to_fix liability is present (mirrors Structural liabilities = Present), so a single column carries both engineering severity and structural disqualification. Lead Selection excludes High and Non-Developable by default.",
+					"pl7.app/description": "Highest risk level across fixable liabilities (deamidation, oxidation, fragmentation, glycosylation). Returns 'Very High' when any hard_to_fix liability is present (e.g. Extra Cysteines) and 'Non-Developable' when any structural liability is present (e.g. Missing Cysteines). A single column carries both engineering severity and structural disqualification. Lead Selection excludes High, Very High, and Non-Developable by default.",
 					"pl7.app/isScore": "true",
 					"pl7.app/isDiscreteFilter": "true",
-					"pl7.app/discreteValues": string(json.encode(["None", "Low", "Medium", "High", "Non-Developable"])),
+					"pl7.app/discreteValues": string(json.encode(["None", "Low", "Medium", "High", "Very High", "Non-Developable"])),
 					"pl7.app/score/rankingOrder": "decreasing",
 					"pl7.app/score/defaultCutoff": string(json.encode(["None", "Low", "Medium"])),
 					"pl7.app/table/visibility": "default",

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -81,12 +81,12 @@ self.body(func(args) {
 				valueType: "String",
 				annotations: {
 					"pl7.app/label": "Structural liabilities",
-					"pl7.app/description": "Present when a conserved disulfide cysteine is missing or an unpaired cysteine appears. Structural issues require scaffold redesign; Lead Selection excludes them by default.",
+					"pl7.app/description": "Present when a Structural or Hard to fix liability is found. Duplicates Developability risk's Non-Developable / Very High overrides — hidden by default.",
 					"pl7.app/isScore": "true",
 					"pl7.app/isDiscreteFilter": "true",
 					"pl7.app/discreteValues": string(json.encode(["None", "Present"])),
 					"pl7.app/score/rankingOrder": "decreasing",
-					"pl7.app/table/visibility": "default",
+					"pl7.app/table/visibility": "hidden",
 					"pl7.app/table/orderPriority": "102"
 				}
 			}


### PR DESCRIPTION
## Summary

Four related fixes to how liability fixability flows into the score columns, from 2026-05-24 / 2026-05-25 Slack feedback:

1. **Per-region `{region} aa risk`** now reflects the worst `riskLevel` of any non-disqualifying liability detected in that region. Previously `hard_to_fix` and `structural` liabilities (e.g. `Extra Cysteines`, or any custom marked "Hard to fix") were silently dropped from per-region risk and only surfaced via the global `Structural liabilities` column.
2. **Global `Developability risk`** gains two new top-level overrides so a single column carries both engineering severity and structural disqualification:
   - `hard_to_fix` liabilities → `Very High`
   - `structural` liabilities → `Non-Developable`
   - Both in the same row → `Non-Developable` wins.
3. **`Structural liabilities` column hidden by default** — Developability risk subsumes its signal at higher resolution. The column stays toggleable in the column picker for users who want the raw boolean.
4. **Internal cleanup**: `classify_risk()` interface tightened (6 params → 3), `classify_developability_risk()` two-loop structure fused into one, unused imports removed from `main.py`.

Sources: 2026-05-24 Slack thread (https://platforma-bio.slack.com/archives/C0ANEG854DT/p1779670038622189) plus 2026-05-25 follow-up feedback in the same thread.

## Behavior diff

| Column | Before | After |
|---|---|---|
| `{region} Liabilities` | Listed all matching liabilities | Unchanged |
| `{region} Risk` | Max risk across `fixable` + `easily_fixable` only | Max risk across all non-disqualifying liabilities |
| `Structural liabilities` | Visible by default; sole source of structural-disqualification signal | Hidden by default; redundant with Developability risk's `Very High` / `Non-Developable` |
| `Developability risk` | `None` / `Low` / `Medium` / `High` | `None` / `Low` / `Medium` / `High` / **`Very High`** (hard_to_fix override) / **`Non-Developable`** (structural override) |
| `Developability cost` | Sum of fixability_weight × region_weight | Unchanged |
| `Is Productive` | `Fail` if any `disqualifying` | Unchanged |

Default Lead Selection cutoff on `Developability risk` stays `[None, Low, Medium]`. High, Very High, and Non-Developable are all filtered out by default.

## Spec choice (Option A → Option B) and developability extensions

### Per-region risk

The spec at `docs/text/work/projects/sequence-liability-fixability-scoring/README.md:126` (Open Questions) listed both behaviors as defensible and deferred the call to the implementor:

> "Should the per-region risk columns reflect *only* fixable liabilities (current proposal) or all liabilities except disqualifying? The proposal keeps structural issues visible at region level for diagnostic purposes; the counter-argument is that FR1 cysteine issues would disappear from CDR/FR-level views. **Implementor decides** based on which is more useful for debugging; either interpretation is defensible."

The v4.0.0 implementor picked Option A (engineering-only). R8 (`:71`), Step 2 (`:252-253`), Defaults (`:304`), M1 (`:346`), and Risks (`:395`) all encoded that choice.

The counter-argument the spec predicted at `:126` — "FR1 cysteine issues would disappear from CDR/FR-level views" — matches what Stanislav reported on Slack ("see last screenshot with CDR3 liabilities in summary VS CDR3 column"). This PR switches to Option B.

### Developability risk extensions

R6 (`:66`) defined `Developability risk` as engineering-only with values `None / Low / Medium / High`. Adding `Very High` and `Non-Developable` extends the scale at the top so the column folds in the structural-liability signal. Rationale: a structurally compromised candidate isn't engineerable regardless of its engineering-risk profile; users should see that directly without cross-referencing `Structural liabilities`.

Confirmed Extra Cysteines as `hard_to_fix` (not `fixable`) — matches our published docs, the LAP profiler paper (PLOS Comp Bio 2024, prevalence ~1% in therapeutics vs ~3–8% in natural repertoires), and industry practice of filtering rather than engineering around free cysteines.

I left the spec doc unchanged (workspace policy). The new semantics live in the `classify_risk()` and `classify_developability_risk()` docstrings, both citing the relevant spec lines.

## Follow-up needed

Public docs at `docs/docs.platforma.bio/` (separate repo) currently describe `Developability risk` as `None / Low / Medium / High` and don't mention the structural overrides or the Structural-liabilities-hidden change. Needs an update PR once this lands. No code dependency.

## Test plan

- [x] `test_custom_liability_per_region_risk_by_fixability` — parametrized over `(easily_fixable, fixable, hard_to_fix)`. Asserts custom riskLevel surfaces in `{region} aa risk`, `Structural liabilities` flips to `Present` only for `hard_to_fix`, and `Developability risk` returns the engineering severity for the engineering classes and `Very High` for hard_to_fix.
- [x] `test_custom_high_overrides_predefined_easily_fixable_medium_in_same_region` — parametrized over `(custom-fixable, custom-hard_to_fix)`. Verifies max-takes on per-region risk and that `Developability risk` is `High` for fixable but `Very High` for hard_to_fix.
- [x] `test_extra_cys_raises_per_region_risk` — predefined hard_to_fix Extra Cysteines in CDR3 → CDR3 Risk = High, Developability risk = Very High.
- [x] `test_missing_cys_raises_fr1_per_region_risk` — predefined structural Missing Cysteines in FR1 → FR1 Risk = High, Developability risk = Non-Developable.
- [x] `test_structural_supersedes_hard_to_fix_in_developability_risk` — combined scenario: structural + hard_to_fix in same row → Non-Developable (worse override wins).
- [x] `test_stop_codon_does_not_raise_per_region_risk` — disqualifying stop codon in CDR1 → CDR1 Risk stays None; Is Productive = Fail. Guards the disqualifying skip in `classify_risk()`.
- [x] `test_missing_cys_is_structural` / `test_extra_cys_is_structural` — updated to assert Developability risk = Non-Developable / Very High (was None under Option A).
- [x] `uv run pytest tests/` — 39 passed
- [x] `pnpm run build:dev` succeeds (9/9 packages)
- [x] Reproduce original user scenarios in a running Platforma instance (Liabilities project, pl MCP). Confirmed: CDR3 Liabilities = `CDR_Cys`, CDR3 Risk = `High`, Developability risk = `Very High`, Developability cost = `12.0` (1.5 CDR3 weight × 8.0 hard_to_fix weight), Structural liabilities column hidden from default view.

## Notes for reviewers

Commit `17f356f` folds three pre-existing single-fixability tests plus one added earlier in this PR into one parametrized test. Same for the max-takes folding: one pre-existing + one PR-internal. Pre-existing tests touched (collapsed into the parametrizations): `test_custom_fixable_liability_raises_per_region_risk`, `test_custom_easily_fixable_liability_raises_per_region_risk`, `test_custom_and_predefined_combine_in_per_region_risk`.

Commit `0f286d3` bumps `@platforma-sdk/block-tools` 2.7.25 → 2.8.3 and `@platforma-sdk/tengo-builder` 2.5.29 → 3.0.3 to satisfy CI's `preflight (require-latest)` check. Only those two; other catalog entries are untouched.

Commit `ba9cb68` refactors `classify_risk` (6 params → 3, knowledge leak removed) and `classify_developability_risk` (two-loop → single-loop). No behavior change.

Commit `8918abb` splits the structural override into the two-tier `Very High` / `Non-Developable` scheme. Built via TDD (4 tests updated to new expectations + 1 new test added → red; impl + Tengo updates → green).

Commit `a637fdf` tightens the Developability risk tooltip text (no behavior change).

Commit `6b0333f` hides Structural liabilities by default and refreshes its tooltip — Developability risk now carries the same signal at higher resolution.

Commit `9975022` removes the Structural liabilities bullet from the block's longDescription (`docs/description.md`) and extends Developability risk's value list to mention `Very High` / `Non-Developable` with examples.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes per-region `{region} aa risk` columns to surface the worst `riskLevel` across **all** non-disqualifying liabilities (Option B), rather than only `fixable`/`easily_fixable` ones, resolving the user-reported inconsistency between the Liabilities and Risk columns. It also extends `Developability risk` with two new top-level values (`Very High` for `hard_to_fix`, `Non-Developable` for `structural`) and hides the now-redundant `Structural liabilities` column by default.

- `classify_risk()` signature tightened to 3 parameters, eliminating the knowledge-leak of definition dicts into the detection layer; `classify_developability_risk()` fused to a single pass with an early `Non-Developable` short-circuit on structural matches.
- Tengo `discreteValues` for `Developability risk` updated to `[\"None\", \"Low\", \"Medium\", \"High\", \"Very High\", \"Non-Developable\"]`; per-region risk columns retain their existing `[\"None\", \"Low\", \"Medium\", \"High\"]` range since structural/hard_to_fix liabilities all carry `riskLevel = \"High\"`.
- Six new / refactored integration tests (including three parametrized) cover all fixability classes, the structural-supersedes-hard_to_fix precedence, and the disqualifying-skip guard.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic changes are well-tested and the single finding is a misleading docstring in the test suite, not incorrect runtime behavior.

The core logic — per-region risk now including hard_to_fix/structural, the two-tier Developability risk overrides, and the Tengo discreteValues update — all appear correct and are covered by 39 passing tests. The only finding is a test docstring that states "Non-Developable when Structural = Present" when the actual behavior for hard_to_fix is "Very High, not Non-Developable". The assertions themselves are right; only the prose explanation is wrong.

liabilities-calc-script/tests/test_integration.py — the docstring of test_custom_liability_per_region_risk_by_fixability should be corrected to distinguish Very High (hard_to_fix) from Non-Developable (structural) when Structural liabilities = Present.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| liabilities-calc-script/src/scoring.py | classify_developability_risk rewritten with two-tier structural overrides (Very High / Non-Developable); short-circuit on structural, deferred return for hard_to_fix. Logic is correct and well-tested. |
| liabilities-calc-script/src/detection.py | classify_risk simplified from 6 params to 3; now includes hard_to_fix/structural liabilities in per-region risk (Option B). Disqualifying skip and early-High short-circuit are preserved correctly. |
| liabilities-calc-script/src/definitions.py | New type aliases (Fixability, RiskLevel, PerRegionRisk, DevelopabilityRisk) added as authoritative source of truth; applied throughout the codebase. |
| liabilities-calc-script/src/main.py | classify_risk call simplified to 3-arg form; unused imports removed; formatting-only reformats for list comprehensions and multi-line conditions. |
| liabilities-calc-script/tests/test_integration.py | Test suite expanded with parametrized tests covering all fixability classes; test assertions are correct but one docstring incorrectly describes Very High as Non-Developable for the hard_to_fix case. |
| workflow/src/clonotype-process.tpl.tengo | Developability risk discreteValues extended to include Very High/Non-Developable; Structural liabilities hidden by default; tooltip text refreshed to match new semantics. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["liability detected in region"] --> B{fixability?}
    B -->|disqualifying| C["skip — surfaces via Is Productive = Fail"]
    B -->|structural| D["classify_risk → contributes riskLevel to per-region max\nclassify_developability_risk → return Non-Developable immediately"]
    B -->|hard_to_fix| E["classify_risk → contributes riskLevel to per-region max\nclassify_developability_risk → set has_hard_to_fix=True, keep scanning"]
    B -->|fixable / easily_fixable| F["both functions → accumulate max riskLevel"]
    E --> G{any structural found\nlater in scan?}
    G -->|yes| H["Developability risk = Non-Developable"]
    G -->|no| I["Developability risk = Very High"]
    F --> J["Developability risk = max of None/Low/Medium/High"]
    D --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
liabilities-calc-script/tests/test_integration.py:511-516
**Misleading docstring for the `hard_to_fix` test case**

The docstring states "switches to Non-Developable when Structural = Present." However, when fixability is `hard_to_fix`, `Structural liabilities` = `"Present"` yet `Developability risk` = `"Very High"` — not `"Non-Developable"`. `Non-Developable` is only produced when the fixability is `structural`. A reader relying on this docstring to understand the contract would form an incorrect mental model: both `hard_to_fix` and `structural` liabilities set the `Structural liabilities` column to `Present`, but they produce different `Developability risk` values.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(liabilities-calc): centralise b..."](https://github.com/platforma-open/antibody-sequence-liabilities/commit/f7ef330b9bdb5b5c4bab60173c0ed9593cf41a28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33811176)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->