### PR TITLE
DO NOT MERGE: canary @v4-beta — verify changeset coverage check

### DIFF
--- a/.changeset/canary-model-covered.md
+++ b/.changeset/canary-model-covered.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.antibody-sequence-liabilities.model": patch
+---
+
+Canary (mixed-coverage test, DO NOT MERGE): this changeset covers the `model` edit. The software package (`liabilities-calc-script`) is intentionally touched without a changeset to verify check-coverage reports only the uncovered gap.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@paulnewling/changeset-coverage-diagnostic-job
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Antibody Sequence Liabilities'
       app-name-slug: 'block-antibody-sequence-liabilities'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Antibody Sequence Liabilities'
       app-name-slug: 'block-antibody-sequence-liabilities'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@paulnewling/changeset-coverage-diagnostic-job
     with:
       app-name: 'Block: Antibody Sequence Liabilities'
       app-name-slug: 'block-antibody-sequence-liabilities'

--- a/liabilities-calc-script/src/main.py
+++ b/liabilities-calc-script/src/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# canary (DO NOT MERGE): touch software package without a changeset — coverage-gap test
 import argparse
 import json
 import os

--- a/model/package.json
+++ b/model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.antibody-sequence-liabilities.model",
   "version": "6.0.2",
-  "description": "Block model",
+  "description": "Block model (canary edit — should trigger check-coverage)",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**DO NOT MERGE.** This PR exists only to canary-test the `actions/changeset/check-coverage` step added to `node-simple-pnpm.yaml` in [milaboratory/github-ci#168](https://github.com/milaboratory/github-ci/pull/168) (merged into `v4-beta`).

## What this PR does

1. **Commit 1** — flips the reusable-workflow reference in `.github/workflows/build.yaml` from `node-simple-pnpm.yaml@v4` → `node-simple-pnpm.yaml@v4-beta`, so this PR's CI run picks up the new check-coverage step.
2. **Commit 2** — edits `model/package.json` (workspace package `@platforma-open/milaboratories.antibody-sequence-liabilities.model`) without adding a changeset. This is a deliberate coverage gap.

## What we expect to observe

In the `check-changesets` job of the `run` workflow:

- The new `Check changeset coverage` step runs after the existing `Check for Changesets` step.
- It reports `@platforma-open/milaboratories.antibody-sequence-liabilities.model` as a workspace package modified without a matching changeset bump.
- Because the step is wired with `continue-on-error: true`, the job remains green and the overall build is unaffected.

## Cleanup

Once observed, revert both commits and force-push, then close this PR without merging. The canary leaves no trace on \`main\`.

Refs: github-ci#168