### PR TITLE
Revert content-hash namespacing, keep dedup improvements

### DIFF
--- a/.changeset/revert-content-hash-namespacing.md
+++ b/.changeset/revert-content-hash-namespacing.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.antibody-sequence-liabilities.workflow": patch
+---
+
+Revert namespacing of output liability columns and the trace step by a content hash of the liability configuration: the column domain and trace step id are keyed on the per-block blockId again. The config-hash helper is removed and blockId is threaded back through the process templates.
+
+The independent re-run deduplication fixes are kept: disabledPredefinedLiabilities is still sorted to a canonical order (slices.sortUnique) inside normalize(), the annotation mapping is still encoded with canonical.encode (key-sorted, deterministic) so identical mappings produce identical column specs across runs, and mem is still passed to the calc renders via metaInputs so it stays out of the content key.

--- a/workflow/src/clonotype-process.tpl.tengo
+++ b/workflow/src/clonotype-process.tpl.tengo
@@ -5,7 +5,6 @@ assets:= import("@platforma-sdk/workflow-tengo:assets") // Asset management
 xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv") // CSV/TSV handling
 pframes := import("@platforma-sdk/workflow-tengo:pframes") // Data frames handling
 pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec") // Specification utilities
-liabilityConfig := import(":liability-config")          // Liability-config normalize + content hash
 canonical := import("@platforma-sdk/workflow-tengo:canonical") // Deterministic, key-sorted JSON encoding
 text := import("text")                                   // Text manipulation utilities
 json := import("json")
@@ -16,12 +15,7 @@ self.defineOutputs("outputLiabilities", "exportPframe")
 
 self.body(func(args) {
 
-    contentHash := liabilityConfig.hash(
-        args.customLiabilities,
-        args.usePredefinedLiabilities,
-        args.disabledPredefinedLiabilities
-    )
-
+    blockId := args.blockId
     customBlockLabel := args.customBlockLabel
     defaultBlockLabel := args.defaultBlockLabel
 
@@ -320,7 +314,7 @@ self.body(func(args) {
 			if !col.spec.domain {
 				col.spec.domain = {}
 			}
-			col.spec.domain["pl7.app/contentHash"] = contentHash
+			col.spec.domain["pl7.app/blockId"] = blockId
 			
 			exportColumns += [col]
 		}
@@ -364,7 +358,7 @@ self.body(func(args) {
 		type: "milaboratories.sequence-liabilities",
 		importance: 30,
 		label: blockLabel,
-		id: contentHash
+		id: blockId
 	}]
 
 	// Create the trace with all steps. Spread operator is used to pass the trace steps as individual arguments.

--- a/workflow/src/liability-config.lib.tengo
+++ b/workflow/src/liability-config.lib.tengo
@@ -1,6 +1,4 @@
 ll := import("@platforma-sdk/workflow-tengo:ll")
-objects := import("@platforma-sdk/workflow-tengo:objects")
-canonical := import("@platforma-sdk/workflow-tengo:canonical")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 
 normalize := func(customLiabilities, usePredefinedLiabilities, disabledPredefinedLiabilities) {
@@ -14,7 +12,7 @@ normalize := func(customLiabilities, usePredefinedLiabilities, disabledPredefine
 	disabled := undefined
 	if usePredefined && disabledPredefinedLiabilities && len(disabledPredefinedLiabilities) > 0 {
 		// Sort to a canonical order: this list is a set, but it reaches the calc
-		// (writeFile + render.create input) and the content hash as a raw array.
+		// (writeFile + render.create input) as a raw array.
 		// The backend canonicalizes map keys on the CID but NOT array element order,
 		// so an unsorted list makes semantically-identical configs hash differently
 		// and re-run the calc across blocks/projects.
@@ -28,12 +26,6 @@ normalize := func(customLiabilities, usePredefinedLiabilities, disabledPredefine
 	}
 }
 
-hash := func(customLiabilities, usePredefinedLiabilities, disabledPredefinedLiabilities) {
-	encoded := canonical.encode(objects.deleteUndefined(normalize(customLiabilities, usePredefinedLiabilities, disabledPredefinedLiabilities)))
-	return ll.base32Encode(ll.sha256Encode(encoded)[0:16])
-}
-
 export ll.toStrict({
-	normalize: normalize,
-	hash: hash
+	normalize: normalize
 })

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -80,6 +80,8 @@ wf.prepare(func(args) {
 
 wf.body(func(args) {
 
+	blockId := wf.blockId().getDataAsJson()
+
 	columnsWithSequences := args.columns
 	datasetSpec := columnsWithSequences.getSpec(args.inputAnchor)
 
@@ -119,9 +121,7 @@ wf.body(func(args) {
 
 		peptideProcess := render.create(peptideProcessTpl, {
 			liabilitiesTable: liabilitiesResult,
-			customLiabilities: liabCfg.customLiabilities,
-			usePredefinedLiabilities: liabCfg.usePredefinedLiabilities,
-			disabledPredefinedLiabilities: liabCfg.disabledPredefinedLiabilities,
+			blockId: blockId,
 			customBlockLabel: args.customBlockLabel,
 			defaultBlockLabel: args.defaultBlockLabel,
 			datasetSpec: datasetSpec
@@ -277,9 +277,7 @@ wf.body(func(args) {
 		liabilitiesTable: liabilitiesResult,
 		newMapping: newMapping,
 		regionsFound: regionsFound,
-		customLiabilities: liabCfg.customLiabilities,
-		usePredefinedLiabilities: liabCfg.usePredefinedLiabilities,
-		disabledPredefinedLiabilities: liabCfg.disabledPredefinedLiabilities,
+		blockId: blockId,
 		customBlockLabel: args.customBlockLabel,
 		defaultBlockLabel: args.defaultBlockLabel,
 		params: smart.createJsonResource({

--- a/workflow/src/peptide-process.tpl.tengo
+++ b/workflow/src/peptide-process.tpl.tengo
@@ -6,7 +6,6 @@ self := import("@platforma-sdk/workflow-tengo:tpl")
 xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
 pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
-liabilityConfig := import(":liability-config")
 json := import("json")
 math := import("math")
 
@@ -15,12 +14,7 @@ self.defineOutputs("outputLiabilities", "exportPframe")
 
 self.body(func(args) {
 
-    contentHash := liabilityConfig.hash(
-        args.customLiabilities,
-        args.usePredefinedLiabilities,
-        args.disabledPredefinedLiabilities
-    )
-
+    blockId := args.blockId
     customBlockLabel := args.customBlockLabel
     defaultBlockLabel := args.defaultBlockLabel
     liabilitiesTable := args.liabilitiesTable
@@ -130,7 +124,7 @@ self.body(func(args) {
             if !col.spec.domain {
                 col.spec.domain = {}
             }
-            col.spec.domain["pl7.app/contentHash"] = contentHash
+            col.spec.domain["pl7.app/blockId"] = blockId
             exportColumns += [col]
         }
     }
@@ -171,7 +165,7 @@ self.body(func(args) {
         type: "milaboratories.sequence-liabilities",
         importance: 30,
         label: blockLabel,
-        id: contentHash
+        id: blockId
     }]
     liabilityTrace := pSpec.makeTrace(datasetSpec, traceSteps...)
 


### PR DESCRIPTION
Switch exported column/axis domain keys and trace IDs back from pl7.app/contentHash (derived from a SHA-256 of the liability config) to pl7.app/blockId, restoring the original per-block namespacing.

Kept dedup improvements:
- liability-config.lib.tengo normalize() still sorts disabledPredefinedLiabilities via slices.sortUnique so semantically-identical configs dedup the calc run.
- liabilityConfig.normalize() is still called in main.tpl.tengo before feeding args to the calc renders (drops inert undefined inputs from the content key).
- metaInputs: { mem: args.mem } pattern is kept on all render.create calls so mem stays out of the content key.

Removed: hash() function and its imports (ll, objects, canonical) from liability-config.lib.tengo; contentHash variable in both process templates.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the column/axis domain key and trace ID from `pl7.app/contentHash` (a SHA-256 of the liability config) back to `pl7.app/blockId`, while keeping the dedup improvements: `normalize()` still sorts `disabledPredefinedLiabilities` via `slices.sortUnique`, `metaInputs: { mem: args.mem }` is preserved on all `render.create` calls, and `liabilityConfig.normalize()` is still called before feeding args to the calc renders.

- `hash()` and its `objects`/`canonical` imports are removed from `liability-config.lib.tengo`; only `normalize()` is exported.
- `main.tpl.tengo` now calls `wf.blockId().getDataAsJson()` once and forwards the scalar `blockId` to both process templates, replacing the three per-field liability-config args that were previously forwarded for hash derivation.
- `clonotype-process.tpl.tengo` additionally swaps `canonical.encode` → `json.encode` for the `newMapping` annotation string — a minor silent change not mentioned in the PR description.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The revert is clean and internally consistent across all four files; the only untracked change is the canonical→json encoder swap for newMapping in the clonotype template.

The blockId wiring is correct end-to-end, normalize() and metaInputs dedup guards are intact, and the hash/canonical/objects removal is complete. The one thing that deserves a second look is clonotype-process.tpl.tengo quietly replacing canonical.encode with json.encode for the newMapping annotation — if downstream annotation-mapping consumers rely on a stable encoding of that string the output could diverge subtly. It is not a blocking issue but it is an unannounced behavioral change on a code path that previously used the deterministic encoder intentionally.

workflow/src/clonotype-process.tpl.tengo — the canonical.encode → json.encode substitution for newMapping should be explicitly verified or reverted.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/liability-config.lib.tengo | Removed hash() function and its canonical/objects imports; only normalize() remains exported. A comment referencing "content hash" was updated accordingly. |
| workflow/src/main.tpl.tengo | blockId is now retrieved from wf.blockId().getDataAsJson() once at the top of wf.body() and passed directly to child render.create calls, replacing the three individual liability-config fields that were forwarded for contentHash derivation. metaInputs pattern is preserved. |
| workflow/src/clonotype-process.tpl.tengo | Removed liabilityConfig and canonical imports; contentHash replaced with blockId from args. Also quietly swaps canonical.encode → json.encode for the newMapping annotation string, a change not mentioned in the PR description. |
| workflow/src/peptide-process.tpl.tengo | Removed liabilityConfig import; contentHash replaced with blockId from args. Cleaner than the clonotype counterpart as it had no canonical.encode usage to swap. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["main.tpl.tengo\nwf.body()"] -->|"blockId = wf.blockId().getDataAsJson()"| B["blockId value"]
    A -->|"liabilityConfig.normalize()"| C["liabCfg\n(sorted, deduped)"]

    C -->|"customLiabilities\nusePredefinedLiabilities\ndisabledPredefinedLiabilities"| D["calculateLiabilitiesTpl\n(calc render — content key)"]
    C -->|"same fields"| E["peptideLiabilitiesTpl\n(calc render — content key)"]

    B -->|"blockId"| F["clonotype-process.tpl.tengo\nrender.create(processTpl)"]
    B -->|"blockId"| G["peptide-process.tpl.tengo\nrender.create(peptideProcessTpl)"]

    F -->|"col.spec.domain[pl7.app/blockId] = blockId"| H["Export columns\n(domain-namespaced)"]
    F -->|"trace id = blockId"| I["pFrame trace"]

    G -->|"col.spec.domain[pl7.app/blockId] = blockId"| J["Export columns\n(domain-namespaced)"]
    G -->|"trace id = blockId"| K["pFrame trace"]

    subgraph "REMOVED (contentHash path)"
        Z1["hash()\nSHA-256 + base32\nof normalized config"]
        Z2["pl7.app/contentHash domain key"]
        Z3["canonical import\nobjects import"]
    end

    style Z1 fill:#ffcccc,stroke:#cc0000
    style Z2 fill:#ffcccc,stroke:#cc0000
    style Z3 fill:#ffcccc,stroke:#cc0000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["main.tpl.tengo\nwf.body()"] -->|"blockId = wf.blockId().getDataAsJson()"| B["blockId value"]
    A -->|"liabilityConfig.normalize()"| C["liabCfg\n(sorted, deduped)"]

    C -->|"customLiabilities\nusePredefinedLiabilities\ndisabledPredefinedLiabilities"| D["calculateLiabilitiesTpl\n(calc render — content key)"]
    C -->|"same fields"| E["peptideLiabilitiesTpl\n(calc render — content key)"]

    B -->|"blockId"| F["clonotype-process.tpl.tengo\nrender.create(processTpl)"]
    B -->|"blockId"| G["peptide-process.tpl.tengo\nrender.create(peptideProcessTpl)"]

    F -->|"col.spec.domain[pl7.app/blockId] = blockId"| H["Export columns\n(domain-namespaced)"]
    F -->|"trace id = blockId"| I["pFrame trace"]

    G -->|"col.spec.domain[pl7.app/blockId] = blockId"| J["Export columns\n(domain-namespaced)"]
    G -->|"trace id = blockId"| K["pFrame trace"]

    subgraph "REMOVED (contentHash path)"
        Z1["hash()\nSHA-256 + base32\nof normalized config"]
        Z2["pl7.app/contentHash domain key"]
        Z3["canonical import\nobjects import"]
    end

    style Z1 fill:#ffcccc,stroke:#cc0000
    style Z2 fill:#ffcccc,stroke:#cc0000
    style Z3 fill:#ffcccc,stroke:#cc0000
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aworkflow%2Fsrc%2Fclonotype-process.tpl.tengo%3A33%0AThe%20swap%20from%20%60canonical.encode%60%20to%20%60json.encode%60%20for%20%60newMapping%60%20is%20a%20silent%20behaviour%20change%20that%20wasn't%20called%20out%20in%20the%20PR%20description.%20%60canonical.encode%60%20guarantees%20deterministic%2C%20key-sorted%20JSON%3B%20%60json.encode%60%20%28Go's%20%60encoding%2Fjson%60%29%20also%20sorts%20map%20keys%20since%20Go%201.12%2C%20but%20the%20two%20encoders%20can%20differ%20in%20how%20they%20handle%20special%20float%20values%2C%20nil-vs-undefined%2C%20and%20other%20edge%20cases.%20Because%20%60newMapping%60%20is%20stored%20as%20a%20string%20annotation%20%28%60pl7.app%2Fsequence%2Fannotation%2Fmapping%60%29%20that%20is%20compared%20by%20downstream%20annotation-mapping%20consumers%2C%20a%20subtly%20different%20encoding%20could%20cause%20those%20consumers%20to%20see%20the%20mapping%20as%20changed%20on%20every%20run.%20Keeping%20%60canonical.encode%60%20would%20maintain%20the%20previous%20guarantee%20without%20requiring%20the%20%60canonical%60%20import%20to%20stay%20for%20hashing.%0A%0A%60%60%60suggestion%0A%20%20%20%20newMapping%20%3A%3D%20canonical.encode%28args.newMapping.getDataAsJson%28%29%29%0A%60%60%60%0A%0A&repo=platforma-open%2Fantibody-sequence-liabilities&pr=67&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
workflow/src/clonotype-process.tpl.tengo:33
The swap from `canonical.encode` to `json.encode` for `newMapping` is a silent behaviour change that wasn't called out in the PR description. `canonical.encode` guarantees deterministic, key-sorted JSON; `json.encode` (Go's `encoding/json`) also sorts map keys since Go 1.12, but the two encoders can differ in how they handle special float values, nil-vs-undefined, and other edge cases. Because `newMapping` is stored as a string annotation (`pl7.app/sequence/annotation/mapping`) that is compared by downstream annotation-mapping consumers, a subtly different encoding could cause those consumers to see the mapping as changed on every run. Keeping `canonical.encode` would maintain the previous guarantee without requiring the `canonical` import to stay for hashing.

```suggestion
    newMapping := canonical.encode(args.newMapping.getDataAsJson())
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert content-hash namespacing, keep de..."](https://github.com/platforma-open/antibody-sequence-liabilities/commit/2987fa3b17002c4967fe9fc34aaf17e42ed71f21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38430288)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->