### PR TITLE
Anchor FR1 conserved-cysteine check from the region end

### DIFF
--- a/.changeset/tough-teams-tan.md
+++ b/.changeset/tough-teams-tan.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.antibody-sequence-liabilities.liabilities-calc-script": patch
+---
+
+Anchor FR1 conserved-cysteine check from the region end so reference framing no longer causes false Missing/Extra Cysteines.

--- a/liabilities-calc-script/src/definitions.py
+++ b/liabilities-calc-script/src/definitions.py
@@ -77,8 +77,11 @@ REGION_WEIGHTS: dict[str, float] = {
 
 _ENGINEERING_FIXABILITIES = {"fixable", "easily_fixable"}
 # Usage of EXPECTED_CYS_BASE will have to be modified if you add more than one nucleotide coordinate
-# Coordinates are added in 0-based index
-EXPECTED_CYS_BASE = {"FR1": [21, 22], "FR2": [], "FR3": [], "CDR1": [], "CDR2": [], "CDR3": [0]}
+# Coordinates are 0-based indices; negative values are counted from the end of the region.
+# FR1's conserved cysteine sits a fixed short distance before CDR1, so it is anchored from the
+# FR1 end ([-4, -3]) rather than the start: start-anchored indices break when the reference
+# framing adds/removes N-terminal residues (e.g. germline-imputed FR1 shifting the cysteine).
+EXPECTED_CYS_BASE = {"FR1": [-4, -3], "FR2": [], "FR3": [], "CDR1": [], "CDR2": [], "CDR3": [0]}
 FR1_SPECIFIC_LIABILITIES = {"Missing Cysteines", "Extra Cysteines"}
 REGION_ORDER_MAP = {"FR1": 1, "CDR1": 2, "CDR2": 3, "CDR3": 4, "FR2": 5, "FR3": 6, "FR4": 7}  # For sorting summary
 


### PR DESCRIPTION
The FR1 cysteine check expected the conserved cysteine at a fixed start position ([21,22]), which assumes mature ~25-residue framing. References that add N-terminal residues (e.g. germline-imputed FR1, 27 residues) shift the cysteine to index 23, so it was missed — falsely flagging Missing Cysteines and forcing clones Non-Developable.

This anchors the check from the FR1 end ([-4,-3]) instead of the start, since the conserved cysteine sits a fixed distance before CDR1. Verified on the client dataset with no regression on the mature set; real missing/extra cysteines are still flagged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the conserved-cysteine position check in FR1 from start-anchored absolute indices (`[21, 22]`) to end-anchored relative indices (`[-4, -3]`), so that germline-imputed or otherwise longer FR1 sequences (e.g., 27 residues) no longer produce false \"Missing Cysteines\" / \"Non-Developable\" flags.

- **`EXPECTED_CYS_BASE["FR1"]` changed to `[-4, -3]`**: Python's negative string indexing is already supported by the `allowed_positions` bounds filter (`-len(seq) <= p < len(seq)`) in `_evaluate_cys_liabilities`, so no changes to detection logic were required.
- **Comment updated in-place**: The surrounding comment block was extended to explain end-anchoring, but the first line retains the older \"nucleotide coordinate\" terminology, which is now slightly inconsistent with the new \"0-based indices\" language.
- **Test gap**: The existing test fixture (`sequences.tsv`) only exercises 25-residue FR1 sequences; no test was added for the 27-residue germline-imputed case that originally motivated this fix.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix is a one-line data change that aligns the cysteine position check with how detection already handles negative indices, and the existing test suite passes without modification.

The core change is biologically well-motivated and technically sound: Python negative indexing is already handled by the `allowed_positions` bounds filter in `_evaluate_cys_liabilities`, and the test fixture (25-residue FR1) confirms the mature-sequence path is unaffected. The only gaps are a stale phrase in the comment block and the absence of a test for the exact germline-imputed 27-residue FR1 case that the PR description says was verified externally.

`liabilities-calc-script/src/definitions.py` is the only changed production file; it would benefit from a 27-residue FR1 test entry in `tests/data/sequences.tsv` to lock in the regression fix permanently.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| liabilities-calc-script/src/definitions.py | Changed FR1 expected cysteine positions from start-anchored [21, 22] to end-anchored [-4, -3]; comment updated but retains a stale "nucleotide coordinate" phrase inconsistent with new "0-based indices" terminology. |
| .changeset/tough-teams-tan.md | Changeset entry accurately describes the patch fix; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FR1 amino-acid sequence] --> B{len >= 4?}
    B -- No --> C[allowed_positions = empty\nno cysteine check performed]
    B -- Yes --> D["allowed_positions = [-4, -3]\n(end-anchored)"]
    D --> E{"seq[-4] == 'C' OR\nseq[-3] == 'C'?"}
    E -- Yes, at least one C found --> F[missing_cys = False]
    E -- No C at either position --> G[missing_cys = True]
    F --> H{actual_cys_count > 1?}
    H -- Yes --> I[extra_cys = True → Extra Cysteines]
    H -- No --> J[No FR1 liability]
    G --> K[Missing Cysteines flag]
    G --> L{actual_cys_count >= 1?}
    L -- Yes --> M[extra_cys = True → Extra Cysteines + Missing Cysteines]
    L -- No --> N[Missing Cysteines only]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[FR1 amino-acid sequence] --> B{len >= 4?}
    B -- No --> C[allowed_positions = empty\nno cysteine check performed]
    B -- Yes --> D["allowed_positions = [-4, -3]\n(end-anchored)"]
    D --> E{"seq[-4] == 'C' OR\nseq[-3] == 'C'?"}
    E -- Yes, at least one C found --> F[missing_cys = False]
    E -- No C at either position --> G[missing_cys = True]
    F --> H{actual_cys_count > 1?}
    H -- Yes --> I[extra_cys = True → Extra Cysteines]
    H -- No --> J[No FR1 liability]
    G --> K[Missing Cysteines flag]
    G --> L{actual_cys_count >= 1?}
    L -- Yes --> M[extra_cys = True → Extra Cysteines + Missing Cysteines]
    L -- No --> N[Missing Cysteines only]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aliabilities-calc-script%2Fsrc%2Fdefinitions.py%3A79-80%0AThe%20first%20line%20of%20the%20comment%20block%20still%20says%20%22nucleotide%20coordinate%22%20%E2%80%94%20a%20term%20from%20the%20original%20comment%20that%20is%20now%20inconsistent%20with%20the%20new%20explanation%20directly%20below%20it%2C%20which%20correctly%20calls%20these%20%220-based%20indices%22%20into%20the%20amino-acid%20sequence.%20Aligning%20the%20vocabulary%20avoids%20confusion%20for%20future%20readers%20who%20may%20take%20%22nucleotide%20coordinate%22%20to%20mean%20a%20position%20in%20DNA.%0A%0A%60%60%60suggestion%0A%23%20Usage%20of%20EXPECTED_CYS_BASE%20will%20have%20to%20be%20modified%20if%20you%20add%20more%20than%20one%20position%20per%20region%20entry.%0A%23%20Coordinates%20are%200-based%20indices%3B%20negative%20values%20are%20counted%20from%20the%20end%20of%20the%20region.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aliabilities-calc-script%2Fsrc%2Fdefinitions.py%3A84%0A**No%20test%20for%20the%20germline-imputed%20%28longer%29%20FR1%20case**%0A%0AThe%20scenario%20that%20motivated%20this%20fix%20%E2%80%94%20a%2027-residue%20FR1%20where%20the%20conserved%20cysteine%20sits%20at%20index%2023%20rather%20than%2021%20%E2%80%94%20has%20no%20corresponding%20entry%20in%20%60tests%2Fdata%2Fsequences.tsv%60.%20All%20existing%20fixture%20sequences%20use%2025-residue%20FR1%20%28%60QVQLVQSGAEVKKPGASVKVSCKAS%60%29%2C%20so%20the%20test%20suite%20only%20validates%20that%20end-anchoring%20still%20detects%20missing%2Fextra%20cysteines%20in%20the%20mature-sequence%20case.%20Adding%20a%2027-residue%20FR1%20clone%20%28with%20and%20without%20the%20cysteine%29%20would%20directly%20document%20the%20regression%20that%20was%20fixed%20and%20guard%20against%20future%20regressions.%0A%0A&repo=platforma-open%2Fantibody-sequence-liabilities&pr=70&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
liabilities-calc-script/src/definitions.py:79-80
The first line of the comment block still says "nucleotide coordinate" — a term from the original comment that is now inconsistent with the new explanation directly below it, which correctly calls these "0-based indices" into the amino-acid sequence. Aligning the vocabulary avoids confusion for future readers who may take "nucleotide coordinate" to mean a position in DNA.

```suggestion
# Usage of EXPECTED_CYS_BASE will have to be modified if you add more than one position per region entry.
# Coordinates are 0-based indices; negative values are counted from the end of the region.
```

### Issue 2 of 2
liabilities-calc-script/src/definitions.py:84
**No test for the germline-imputed (longer) FR1 case**

The scenario that motivated this fix — a 27-residue FR1 where the conserved cysteine sits at index 23 rather than 21 — has no corresponding entry in `tests/data/sequences.tsv`. All existing fixture sequences use 25-residue FR1 (`QVQLVQSGAEVKKPGASVKVSCKAS`), so the test suite only validates that end-anchoring still detects missing/extra cysteines in the mature-sequence case. Adding a 27-residue FR1 clone (with and without the cysteine) would directly document the regression that was fixed and guard against future regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["changeset"](https://github.com/platforma-open/antibody-sequence-liabilities/commit/2f3f53ca6e0d3c218eb4a22282057f0d070e8d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39436181)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->