### PR TITLE
chore: publish to stable channel (remove --unstable flag)

### DIFF
--- a/.changeset/publish-to-stable-channel.md
+++ b/.changeset/publish-to-stable-channel.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.antibody-sequence-liabilities': patch
+---
+
+Publish to the stable channel by default — remove the `--unstable` flag from the block's publish script.

--- a/block/package.json
+++ b/block/package.json
@@ -5,7 +5,7 @@
     "build": "shx rm -rf ./block-pack && block-tools pack",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish --unstable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'"
+    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'"
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
## What

Remove the `--unstable` flag from the block's `prepublishOnly` script in `block/package.json`.

## Why

With `--unstable`, every CI release publishes the block without adding it to the `stable` channel, so the block only appears in the unstable channel. Removing the flag restores the default behavior: `block-tools publish` auto-adds the published version to the stable channel, so the next release reaches users on the stable channel.

The manual `mark-stable` script/workflow remains available as before.

## Changes

- `block/package.json`: `block-tools publish --unstable -r …` → `block-tools publish -r …`
- Changeset: `patch` bump on the root block package so a release is cut.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `--unstable` flag from the `prepublishOnly` script in `block/package.json` so that future CI releases publish the block to the **stable** channel by default. A patch-level changeset is included to trigger a release cut.

- **`block/package.json`**: `block-tools publish --unstable -r …` → `block-tools publish -r …`, meaning the next `npm publish` run will automatically add the new version to the stable channel in the S3 block registry.
- **`.changeset/publish-to-stable-channel.md`**: Adds a `patch` bump entry for `@platforma-open/milaboratories.antibody-sequence-liabilities` so the CI release workflow produces a new version.

**Touched terms**:
- **`prepublishOnly`** (npm lifecycle hook): Runs automatically before every `npm publish`. Previously invoked `block-tools publish --unstable`, which skipped stable-channel promotion; now invokes `block-tools publish` without the flag, restoring default stable-channel publishing.
- **`--unstable`** (block-tools flag): When present, signals `block-tools publish` to upload the block without updating the stable channel pointer. Its removal is the core change of this PR.
- **`mark-stable`** (npm script): A manual script invoking `block-tools mark-stable` against the same S3 registry. It is unchanged and remains available for manual stable promotions when needed.
- **`changeset`** (versioning artifact): A Changesets-format frontmatter file that declares a `patch` version bump, consumed by the CI release workflow to generate a new semver tag and CHANGELOG entry.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single flag removal in a publish script with no impact on build output or runtime behavior.

The only change is dropping `--unstable` from the `prepublishOnly` npm script. This has no effect on the block's code, tests, or build artifacts — it only changes how the next release is registered in the S3 block registry. The changeset is correctly scoped and the description matches the intent.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| block/package.json | Removes `--unstable` from `prepublishOnly` publish command; single flag removal with clear, intended effect on stable-channel promotion. |
| .changeset/publish-to-stable-channel.md | New patch-level changeset to trigger a release; correctly targets the root block package with an accurate description. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Release Workflow
    participant npm as npm publish
    participant bt as block-tools publish
    participant S3 as S3 Block Registry

    CI->>npm: pnpm publish (triggers prepublishOnly)
    npm->>bt: block-tools pack
    bt-->>npm: block-pack ready
    npm->>bt: block-tools publish -r s3://…registry…
    note over bt,S3: Before this PR: --unstable flag<br/>skipped stable channel update
    bt->>S3: Upload block artifact
    bt->>S3: Update stable channel pointer
    S3-->>CI: ✅ Block visible on stable channel
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Release Workflow
    participant npm as npm publish
    participant bt as block-tools publish
    participant S3 as S3 Block Registry

    CI->>npm: pnpm publish (triggers prepublishOnly)
    npm->>bt: block-tools pack
    bt-->>npm: block-pack ready
    npm->>bt: block-tools publish -r s3://…registry…
    note over bt,S3: Before this PR: --unstable flag<br/>skipped stable channel update
    bt->>S3: Upload block artifact
    bt->>S3: Update stable channel pointer
    S3-->>CI: ✅ Block visible on stable channel
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: publish to stable channel (remove..."](https://github.com/platforma-open/antibody-sequence-liabilities/commit/43391db66af6da75a9bf3f0cd0f088742e2f3a2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39580848)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->